### PR TITLE
docs: add simplified agents API proposal with middleware examples

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,536 @@
+# Sweatpants Architecture
+
+This document describes the architecture for Sweatpants, an agent framework built on Effection's structured concurrency primitives.
+
+## Overview
+
+Sweatpants provides a composable, middleware-driven architecture for building AI agents. The design emphasizes:
+
+- **Structured concurrency**: All operations are coroutines with predictable lifecycle management
+- **Protocol-based communication**: Declaration separate from implementation enables environment-agnostic code
+- **Middleware at every level**: Intercept and transform any operation at any scope
+- **Context-driven resolution**: Configuration and implementations flow down the coroutine hierarchy
+
+## Foundation: Effection Structured Concurrency
+
+The architecture is built on Effection's structured concurrency model:
+
+- **Coroutines** (`function*` / `yield*`) as the execution primitive
+- **Scopes** form a hierarchy (parent → child relationships)
+- **Context** flows down the scope tree, can be overridden at any level
+- **Resources** are bound to scope lifetime (automatic cleanup)
+
+## Composition Hierarchy
+
+The system has three levels of composition:
+
+```
+Program
+  └── Agents (coroutines with tools, stateful or stateless)
+        └── Tools (operations that use core primitives)
+```
+
+### Program Level
+
+The program is the entry point. It sets root context, loads configuration, starts the server, and instantiates agents.
+
+```ts
+import { main } from "effection";
+import { createServer, useConfig, useModel } from "@sweatpants/core";
+import { Chat } from "./agents/chat";
+
+await main(function* () {
+  const config = yield* useConfig();
+
+  const server = createServer({
+    host: config.server.host,
+    port: config.server.port,
+  });
+
+  yield* useModel(config.defaults.provider, config.defaults.model);
+
+  const agent = yield* Chat;
+
+  server.use("/chat", agent);
+
+  yield* server;
+});
+```
+
+### Agent Level
+
+Each agent has a role defined by the tools it exposes. Agents can be stateful (maintain resources, accumulate state) or stateless (pure transformations).
+
+```ts
+const Chat = createAgent({
+  bookFlight: createTool("book-flight")
+    .description("Search for a flight and book it")
+    .parameter(z.string().describe("Description of a trip"))
+    .execute(function* (trip) {
+      // Agent implementation
+    }),
+});
+```
+
+**Agent instantiation:**
+
+- **Explicit**: `yield* Agent` — starts the coroutine, binds resources, puts instance in context
+- **Implicit**: Call `Agent.tools.method()` — resolves agent from context (suitable for stateless agents)
+
+**Agent identity is context-dependent**: The same code (`Flight.tools.search`) can talk to different agent instances based on what's in the coroutine context. Parent coroutines can override agent instances for their children.
+
+### Tool Level
+
+Tools are operations that use core primitives and can call other agents' tools.
+
+```ts
+const Chat = createAgent({
+  bookFlight: createTool("book-flight")
+    .execute(function* (trip) {
+      // Use core primitives
+      const summary = yield* sample({ prompt: `...` });
+      yield* notify("Processing...", 0.5);
+
+      // Call another agent's tool
+      const result = yield* Flight.tools.search({
+        destination,
+        date,
+      });
+
+      return Ok(result);
+    }),
+});
+```
+
+Tools can be exported as standalone functions for use in distributed libraries:
+
+```ts
+export const { bookFlight } = Chat.tools;
+```
+
+## Core Primitives
+
+The core primitives from `@sweatpants/agent` are the building blocks all other tools are built from:
+
+| Primitive | Purpose |
+|-----------|---------|
+| `sample` | LLM calls with pipeline stages |
+| `elicit` | Structured user input |
+| `notify` | Progress/status to user |
+| `log` | Logging |
+
+### Sample Pipeline
+
+The `sample` primitive is a pipeline with middleware points at each stage:
+
+```
+sample.input → sample.output → sample.metadata → sample.confidence
+```
+
+| Stage | Purpose | Middleware Use Case |
+|-------|---------|---------------------|
+| `input` | Prepare/transform prompt | PII filtering, prompt enrichment |
+| `output` | Handle raw model response | Retry on invalid format, parse/validate |
+| `metadata` | Extract structured data | Control extraction, transform structure |
+| `confidence` | Evaluate confidence | Retry if below threshold, escalate |
+
+When middleware at any stage decides to retry, execution returns to `input` and the full pipeline re-runs.
+
+```ts
+const result = yield* sample({
+  prompt: `Extract destination and date from: ${trip}`,
+  maxTokens: 150,
+});
+// Returns structured data with confidence
+```
+
+### Elicit Types
+
+Elicit is a general mechanism for requesting something from the user's environment. Each elicit type has a schema and corresponding implementation.
+
+**Framework-provided elicit types:**
+
+```ts
+import { createElicit } from "@sweatpants/agent";
+
+export const locationElicit = createElicit({
+  name: "location",
+  description: "Request user location from device GPS",
+  input: z.object({ accuracy: z.enum(["high", "low"]) }),
+  output: z.object({ lat: z.number(), lng: z.number() }),
+  actions: ["accept", "denied", "cancel"],
+});
+
+export const clipboardReadElicit = createElicit({
+  name: "clipboard-read",
+  description: "Read text from user clipboard",
+  input: z.object({}),
+  output: z.object({ text: z.string() }),
+  actions: ["accept", "denied", "cancel"],
+});
+
+export const clipboardWriteElicit = createElicit({
+  name: "clipboard-write",
+  description: "Copy text to user clipboard",
+  input: z.object({ text: z.string() }),
+  output: z.object({ success: z.boolean() }),
+  actions: ["accept", "denied"],
+});
+```
+
+**Custom app-specific elicit types:**
+
+```ts
+const flightSelectionElicit = createElicit({
+  name: "flight-selection",
+  description: "User selects a flight from options",
+  input: z.object({
+    flights: z.array(FlightSchema),
+    message: z.string(),
+  }),
+  output: z.object({
+    flightId: z.string(),
+    seat: z.string(),
+  }),
+});
+```
+
+**Elicit return type:**
+
+```ts
+type ElicitResult<T> =
+  | { action: "accept"; content: T }
+  | { action: "decline" }        // user explicitly said no
+  | { action: "cancel" }         // user dismissed/closed
+  | { action: "denied" }         // permission denied (device APIs)
+  | { action: "other"; content: string }; // user went off-script
+```
+
+## Protocol System
+
+The protocol system separates declaration from implementation, enabling environment-agnostic method invocation.
+
+### Declaration
+
+Protocols define method signatures with schemas for args, progress, and returns:
+
+```ts
+import { createProtocol } from "@sweatpants/core";
+
+const protocol = createProtocol({
+  echo: {
+    args: schema.StringArr,
+    progress: schema.Progress,
+    returns: schema.Result,
+  },
+});
+```
+
+### Implementation
+
+Implementations are environment-specific:
+
+```ts
+import { createImplementation } from "@sweatpants/core";
+
+const inspector = createImplementation(protocol, function* () {
+  return {
+    *echo(...args): Stream<Progress, Result> {
+      // Browser implementation, CLI implementation, test mock, etc.
+    },
+  };
+});
+```
+
+### Usage
+
+```ts
+const handle = yield* inspector.attach();
+const stream = handle.invoke({ name: "echo", args: ["hello"] });
+```
+
+### Key Properties
+
+- **Methods return `Stream<Progress, Return>`**: Progress events flow during execution, final result closes the stream
+- **Same protocol, multiple implementations**: UI chat, CLI, test mock, automated
+- **Transport is contextual**: WebSocket, HTTP SSE, in-memory — caller doesn't know or care
+
+### Example: Elicit Across Environments
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                         BACKEND                                 │
+│                                                                 │
+│   Chat Agent                                                    │
+│   ┌─────────────────────────────────────────────────────────┐   │
+│   │  yield* elicit({                                        │   │
+│   │    type: 'form',                                        │   │
+│   │    message: "Select a flight",                          │   │
+│   │    schema: FlightSelectionSchema                        │   │
+│   │  })                                                     │   │
+│   └─────────────────────────────────────────────────────────┘   │
+│                              │                                  │
+│                              │ invoke via protocol              │
+│                              ▼                                  │
+│   ┌─────────────────────────────────────────────────────────┐   │
+│   │  Protocol: elicit                                       │   │
+│   │  - args: { type, message, schema }                      │   │
+│   │  - progress: { status }                                 │   │
+│   │  - returns: { action, content }                         │   │
+│   └─────────────────────────────────────────────────────────┘   │
+│                              │                                  │
+└──────────────────────────────│──────────────────────────────────┘
+                               │ transport (contextual)
+┌──────────────────────────────│──────────────────────────────────┐
+│                         FRONTEND                                │
+│                              ▼                                  │
+│   ┌─────────────────────────────────────────────────────────┐   │
+│   │  Implementation: elicit (UI Chat)                       │   │
+│   │  - Renders flight selection form                        │   │
+│   │  - Streams progress: "rendering" → "waiting"            │   │
+│   │  - Returns: { action: 'accept', content: { flightId } } │   │
+│   └─────────────────────────────────────────────────────────┘   │
+│                                                                 │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## Middleware System
+
+Middleware can intercept any operation at any level of the scope hierarchy.
+
+### Installation
+
+```ts
+yield* api.decorate(
+  {
+    methodName(args, next) {
+      // transform args
+      const result = next(...args);
+      // transform result
+      return result;
+    },
+  },
+  { at: "max" | "min" }
+);
+```
+
+### Priority: max vs min
+
+- **max**: First to see input (outer scopes outermost)
+- **min**: First to see output (inner scopes closest to core)
+
+### Execution Order
+
+```
+OUTER SCOPE (max) ────────────────────────────────────────────────────────
+  │                                                                     ▲
+  ▼                                                                     │
+INNER SCOPE (max) ────────────────────────────────────────────────      │
+  │                                                              ▲      │
+  ▼                                                              │      │
+INNER SCOPE (min) ────────────────────────────────────────       │      │
+  │                                                      ▲       │      │
+  ▼                                                      │       │      │
+OUTER SCOPE (min) ────────────────────────────           │       │      │
+  │                                          ▲           │       │      │
+  ▼                                          │           │       │      │
+                      CORE                   └───────────┴───────┴──────┘
+```
+
+### Use Cases
+
+**PII filtering (max priority):**
+
+```ts
+yield* around(
+  {
+    *sample([{ prompt, maxTokens }], next) {
+      const sanitizedPrompt = redactPII(prompt);
+      return yield* next({ prompt: sanitizedPrompt, maxTokens });
+    },
+  },
+  { at: "max" }
+);
+```
+
+**Confidence checking (min priority):**
+
+```ts
+yield* around(
+  {
+    *sample([args], next) {
+      const result = yield* next(args);
+      if (result.confidence < 0.8) {
+        // retry or escalate
+      }
+      return result;
+    },
+  },
+  { at: "min" }
+);
+```
+
+**Scoped configuration:**
+
+```ts
+const HttpConfig = Context.create<{ retries: number; timeout: number }>(
+  "http-config",
+  { retries: 3, timeout: 5000 }
+);
+
+// Increase retries for flaky services
+yield* HttpConfig.with({ retries: 10, timeout: 15000 }, function* () {
+  yield* ExternalServiceAgent.tools.fetchData({ endpoint: "/unstable-api" });
+});
+```
+
+## Plugin System
+
+Plugins extend agent capabilities through a unified `use` interface.
+
+```ts
+yield* agent.use(plugin);
+```
+
+- Plugins define extension points
+- Agents implement required interfaces for compatibility
+- Type safety + runtime validation enforce compatibility
+
+Examples: HTTP routes, MCP exposure, transport bindings.
+
+## Result Handling
+
+The `Ok`/`Err` pattern distinguishes expected outcomes from unexpected failures:
+
+```ts
+import { Ok, Err } from "effection";
+
+function* bookFlight(flightId: string) {
+  const confirmation = yield* elicit(confirmationElicit);
+
+  if (confirmation.action === "decline") {
+    return Err(new Error("user_declined"));
+  }
+
+  if (confirmation.action === "cancel") {
+    return Err(new Error("user_cancelled"));
+  }
+
+  // ... proceed with booking
+  return Ok({ bookingId: "..." });
+}
+```
+
+Callers must handle results explicitly — there's no automatic propagation.
+
+## Agent State Management
+
+### State Encapsulation
+
+State is encapsulated within agents and accessed only through their tools. There is no point-to-point state communication between agents.
+
+### Fork/Forward/Back
+
+Parent agents can manage subagent state through fork/forward/back operations:
+
+- **Fork**: Create a branch of execution with copied state
+- **Forward**: Advance state (commit)
+- **Back**: Restore to a previous checkpoint
+
+This enables scenarios like "try this approach, if it fails, roll back and try another."
+
+### Side Quests
+
+Users can take tangents mid-conversation without losing context:
+
+```
+Main flow                          Side quest
+──────────                         ──────────
+
+1. Agent asks about flight
+2. User selecting dates
+3. yield* elicit(dateSelection)
+        │
+        │ ◄── User: "Wait, what's the weather in Tokyo?"
+        │
+        ├─────────────────────────► 4. Fork: new coroutine
+        │ (suspended, not lost)        5. Weather agent responds
+        │                              6. User: "Ok thanks"
+        │                              7. Coroutine completes
+        │ ◄────────────────────────────┘
+        │
+        ▼ (resume exactly here)
+4. User completes date selection
+5. Agent continues booking
+```
+
+**Properties:**
+
+- Coroutine tree, not stack — suspended state preserved
+- Auto-return on completion (default behavior)
+- Optional explicit navigation for power users
+- Serializable state for persistence (architected from start, required by 1.0)
+
+## Elicit Use Cases
+
+### Multiple Agents Sharing Same Elicit
+
+- Single implementation serves all agents
+- Requests queue by default; UI controls queue behavior
+- Coroutine context provides agent identity for attribution
+
+### Agent Asking User for Input via Chat
+
+- Typed elicit components with schemas
+- Calling coroutine suspends; others can continue
+- `action: 'other'` for when user goes off-script
+
+### MCP Invoking Tool Which Causes Elicit
+
+- Agent decoupled from invocation source (MCP, HTTP) and elicit target (chat UI, CLI)
+- MCP blocks until user completes elicit
+- Same tool code works regardless of invocation path
+
+### Device API Access (Location, Clipboard)
+
+- Elicit broader than forms — device capability access
+- Permission denial is `{ action: 'denied' }`, not an error
+- Framework provides standard elicit types with `createElicit`
+
+### Backend-Authoritative Interactions
+
+- Backend controls state, validation, authorization
+- Frontend is presentation layer only
+- Example: "Draw a card" — backend picks, frontend reveals
+
+### Compound Elicits (Choice + Type Something)
+
+- Single elicit type = single UI component
+- Compound schema handles multiple interaction modes
+- Distinct from `action: 'other'` (designed option vs. off-script)
+
+## Testing
+
+Testing is a first-class concern. The context-based resolution enables clean substitution:
+
+```ts
+// Inject mock agents
+yield* FlightContext.set(mockFlightAgent, function* () {
+  // Chat's calls to Flight hit the mock
+  yield* Chat.tools.bookFlight(...);
+});
+
+// Inject mock elicit implementation
+yield* ElicitProtocol.implement(testElicitMock);
+```
+
+## Open Areas
+
+The following areas require further design:
+
+- Exact rules for implicit vs explicit agent instantiation
+- Fork/forward/back API specifics
+- Plugin extension point interface design
+- MCP bidirectional integration (exposing tools + consuming external tools)
+- Pipeline stages for `elicit`/`notify`
+- Tangent detection (system-level vs agent-level)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -233,12 +233,11 @@ const LocationProtocol = createProtocol({
 
 ```ts
 import { createImplementation, call } from "@sweatpants/core";
-import { send } from "@sweatpants/agent";
 
 const browserLocation = createImplementation(LocationProtocol, function* () {
   return {
-    *getLocation({ accuracy }) {
-      // send is a free function that uses context to stream progress back
+    // send is passed as second argument, typed to the protocol's progress schema
+    *getLocation({ accuracy }, send) {
       yield* send({ status: "requesting-permission" });
 
       const position = yield* call(() =>

--- a/docs/simplified-agents-api.md
+++ b/docs/simplified-agents-api.md
@@ -1,0 +1,462 @@
+# Purpose
+
+Propose an alternative API for defining agents that aligns better with Effection
+to leverage Structure Concurrency and simplify the API. The simplifaction comes
+from dramatically reducing API surface and leveraging Effection features and
+middleware.
+
+## Approach
+
+At the high level, the API is designed for composition and flexibility.
+
+### Composition
+
+Composition has 3 levels: program, agents and tools.
+
+#### Program level
+
+The program level is the entrypoint into the program. This is where all of the root Effections contexts are set.
+This is where you would load configuration, instantiate all of the agents that start when the program starts. 
+
+```ts
+import z from "zod";
+import { Ok, Err, main } from "effection";
+import { createAgent, createTool, createServer, createMCP, useModel, useConfig } from "@sweatpants/core";
+import { notify, elicit, sample, log } from "@sweatpants/agent";
+
+await main(function* () {
+  const config = yield* useConfig();
+
+  const server = createServer({
+    // this would probably be the default
+    host: config.server.host,
+    port: config.server.port,
+  });
+
+  // this would be built in behavior, but I'm show it as an example
+  yield* useModel(config.defaults.provider, config.defaults.model);
+
+  // I'm not sure about everything below
+  const agent = yield* Chat;
+  const mcp = yield* MCP.config({
+    protocol: config.mcp.protocol
+  });
+
+  server.use('/chat', agent);
+
+  yield* agent.use(mcp);
+
+  yield server;
+});
+```
+
+#### Agent Level
+
+Each agent has a role. It's role is defined by the tools that it uses.
+Agents can use other agent's tools. The configuration for each agent is 
+set at the root level. In the example below, the Chat agent is the 
+orchestrating agent. It uses the Flight agent. 
+
+#### Tool Level
+
+At the tool level, we can use other agent's tool and own tools.
+
+```ts
+const Chat = createAgent({
+  bookFlight: createTool("book-flight")
+    ...
+    .execute(function*(trip) {
+      ...
+      // the type here would be the return type of execute
+      const result = yield* Flight.tools.search({
+        destination,
+        date,
+      });
+      ...
+    })
+});
+```
+
+The tools for each agent are designed to be usable as standalone functions like the
+once provided by `@sweatpants/core` such as `notify`, `elicit`, `sample` 
+and `log`. These functions access teh context to get configuration and 
+determine which model to use.
+
+```ts
+const Chat = createAgent({
+  bookFlight: createTool("book-flight")
+});
+
+export const { bookFlight } = Chat.tools;
+```
+
+This allows each tool to be exported as a standalone function that can be used in agents
+that are distributed as libraries.
+
+### Flexibility
+
+Flexibility comes from having middleware built into the core of every aspect of Sweatpants.
+This allows controlling execution of every tool and it's context from the program level 
+or agent level. To understand middleware, you need keep in mind the following.
+
+You can configure middleware at the root,
+```ts
+import { around } from '@sweatpants/core'
+
+await main(function*() {
+  yield* around({
+    *sample([{ prompt, maxTokens }], next) {
+      // here you can control what happens before sample is called
+      // you can change arguments sent to sample or modify it's context
+      const result = yield* next({ prompt, maxTokens });
+      // here you can decide what to do with the result
+      // you can modify it, invoke other code
+      return result; // you must return if the function has a return value
+    },
+    // same can be done for each of the following: 
+    notify, 
+    elicit,
+    log([message, options], next) {
+      // it's common to want to add metadata to log
+      return next(message, {
+        ...options,
+        metadata: ['XYZ']
+      })
+    }
+  });
+})
+```
+
+The same can be done for each agent's tools.
+```ts
+await main(function*() {
+  yield* Flight.around({
+    search([{ destination, date }], next) {
+      // you can enrich destination or date before it's sent to default function
+      const result = yield* next({ destination, date });
+      // you can modify the result.
+      return result;
+    }
+  })
+});
+
+```
+
+#### Use case: Prevent leaking PII to models
+
+When agents process user data, they may encounter personal identifying information (PII) such as emails, phone numbers, or social security numbers. Middleware allows you to intercept and redact this sensitive data before it reaches the model.
+
+```ts
+await main(function*() {
+  // Helper function to redact common PII patterns
+  function redactPII(text: string): string {
+    return text
+      // Email addresses
+      .replace(/[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/g, '[EMAIL REDACTED]')
+      // Phone numbers (various formats)
+      .replace(/(\+?1[-.\s]?)?\(?\d{3}\)?[-.\s]?\d{3}[-.\s]?\d{4}/g, '[PHONE REDACTED]')
+      // SSN
+      .replace(/\d{3}[-.\s]?\d{2}[-.\s]?\d{4}/g, '[SSN REDACTED]')
+      // Credit card numbers
+      .replace(/\d{4}[-.\s]?\d{4}[-.\s]?\d{4}[-.\s]?\d{4}/g, '[CARD REDACTED]');
+  }
+
+  yield* around({
+    // Intercept all sample calls to sanitize PII in prompts and responses
+    *sample([{ prompt, maxTokens }], next) {
+      // Redact PII from the prompt before sending to model
+      const sanitizedPrompt = redactPII(prompt);
+      const result = yield* next({ prompt: sanitizedPrompt, maxTokens });
+      return result;
+    }
+  });
+
+  // You can also wrap specific agent tools that handle user data
+  yield* CustomerAgent.around({
+    *lookupCustomer([{ customerId }], next) {
+      const result = yield* next({ customerId });
+
+      if (result.ok) {
+        // Redact PII from customer data before returning to the model
+        return Ok({
+          ...result.value,
+          email: '[EMAIL REDACTED]',
+          phone: '[PHONE REDACTED]',
+          ssn: '[SSN REDACTED]',
+          // Keep non-sensitive fields
+          name: result.value.name,
+          accountStatus: result.value.accountStatus
+        });
+      }
+
+      return result;
+    }
+  });
+});
+```
+
+This pattern ensures that sensitive personal information never reaches the model, maintaining user privacy while still allowing agents to process and respond to user requests.
+
+#### Use case: Controlling HTTP retry with Context boundaries
+
+Let's say you have a tool that calls other agents which in turn might call other agents. Some of those agents might be flaky so you want to give them more retry attempts. Using Effection's Context API, you can establish scope-local configuration that flows down to nested operations without global mutation.
+
+```ts
+import { Context } from 'effection';
+import { createAgent, createTool } from '@sweatpants/core';
+
+// Define a context for HTTP configuration
+const HttpConfig = Context.create<{ retries: number; timeout: number }>('http-config', {
+  retries: 3,
+  timeout: 5000
+});
+
+await main(function*() {
+  // Set default HTTP config at the root level
+  yield* HttpConfig.set({ retries: 3, timeout: 5000 });
+
+  // For flaky external services, increase retries in that scope
+  yield* HttpConfig.with({ retries: 10, timeout: 15000 }, function*() {
+    // All operations within this scope inherit the increased retry config
+    yield* ExternalServiceAgent.tools.fetchData({ endpoint: '/unstable-api' });
+  });
+
+  // Outside the scope, config returns to default
+  yield* InternalAgent.tools.getData({ id: '123' }); // Uses default: 3 retries, 5000ms timeout
+});
+
+// Tools can read the current context to respect the configuration
+const ExternalServiceAgent = createAgent({
+  fetchData: createTool('fetch-data')
+    .parameters(z.object({ endpoint: z.string() }))
+    .execute(function*({ endpoint }) {
+      const config = yield* HttpConfig.get();
+
+      let lastError;
+      for (let attempt = 0; attempt < config.retries; attempt++) {
+        try {
+          const response = yield* fetchWithTimeout(endpoint, config.timeout);
+          return Ok(response);
+        } catch (error) {
+          lastError = error;
+          yield* log('warn', `Attempt ${attempt + 1}/${config.retries} failed, retrying...`);
+        }
+      }
+
+      return Err(lastError);
+    })
+});
+```
+
+This pattern leverages Effection's structured concurrency to ensure configuration changes are scoped and don't leak across boundaries. Children inherit parent context, but modifications in child scopes don't affect siblings or parents.
+
+# Example
+
+```ts
+import z from "zod";
+import { Ok, Err, main } from "effection";
+import { createAgent, createTool, createServer, createMCP, useModel, useConfig } from "@sweatpants/core";
+import { notify, elicit, sample, log } from "@sweatpants/agent";
+
+await main(function* () {
+  const config = yield* useConfig();
+
+  const server = createServer({
+    // this would probably be the default
+    host: config.server.host,
+    port: config.server.port,
+  });
+
+  // this would be built in behavior, but I'm show it as an example
+  yield* useModel(config.defaults.provider, config.defaults.model);
+
+  // I'm not sure about everything below
+  const agent = yield* Chat;
+  const mcp = yield* MCP;
+
+  server.use('/chat', agent);
+
+  yield* agent.use(mcp);
+
+  yield server;
+});
+
+const MCP = createMPC({
+  tools: [
+    Chat.tools.bookFlight,
+  ]
+})
+
+const Chat = createAgent({
+  bookFlight: createTool("book-flight")
+    .description("Search for a flight and book it")
+    .parameter(
+      z.string().describe("Description of a trip")
+    )
+    .execute(function*(trip) {
+      let destination, date;
+      while (!destination && !date) {
+        // let's pretend this returns structured data
+        const summary = yield* sample({
+          prompt: `
+            input: ${trip}
+            output: Destination and date of desired trip
+            confidence_level: 0-1
+            confidence_reason: explanation of the confidence level for the user
+          `,
+          maxTokens: 150,
+        });
+
+        if (summary.confidence * 100 > 80) {
+          destination = summary.destination;
+          date = summary.date;
+          break;
+        } else {
+          yield* notify(summary.confidence_reason);
+        }
+      }
+
+      // the type here would be the return type of execute
+      const result = yield* Flight.tools.search({
+        destination,
+        date,
+      });
+
+      if (!result.ok) {
+        return result;
+      }
+
+      const booking = yield* Flight.tools.search({
+        id: result.value.flight,
+        seat: result.value.seatPreference
+      });
+    })
+});
+
+
+const Flight = createAgent({
+  search: createTool("search")
+    .description("Search and select a flight")
+    .parameters(
+      z.object({
+        destination: z.string().describe("Destination city or airport code"),
+        date: z.string().describe("Travel date (YYYY-MM-DD)"),
+      }),
+    )
+    .execute(function* ({ destination, date }) {
+      const flights = yield* searchFlights({ destination, date });
+
+      yield* notify("Found available flights", 0.2);
+
+      // Format flights for display
+      const flightOptions = flights
+        .map(
+          (f) =>
+            `${f.id}: ${f.airline} - ${f.departure} to ${f.arrival} ($${f.price})`,
+        )
+        .join("\n");
+
+      // First elicitation: Pick a flight
+      const selection = yield* elicitFlightSelection(flightOptions);
+
+      // Handle user declining
+      if (selection.action === "decline") {
+        yield* log("info", "User declined flight selection");
+        return Err(new Error("user_declined_selection"));
+      }
+
+      // Handle user cancelling (dismissing dialog)
+      if (selection.action === "cancel") {
+        yield* log("info", "User cancelled flight selection");
+        return Err(new Error("user_cancelled"));
+      }
+
+      // Find the selected flight
+      const selectedFlight = flights.find(
+        (f) => f.id === selection.content.flightId,
+      );
+
+      if (!selectedFlight) {
+        return Err(new Error("invalid_flight_id"));
+      }
+
+      return Ok({
+        flight: selectedFlight,
+        seatPreference
+      })
+    }),
+
+  book: createSearch("book")
+    .description("Book a flight by id")
+    .parameters({
+      id: z.number().required().description("ID of the flight that user wants to book"),
+      seat: z
+        .enum(["window", "aisle", "middle"])
+        .describe("Seat preference"),
+    })
+    .execute: function*({ id, seat }) {
+      
+      const flight = yield* fetch(`/api/flights/${id}`);
+
+      const summary = yield* sample({
+        prompt: `Summarize this flight booking in a friendly, concise way:
+          - Flight: ${flight.airline} ${flight.id}
+          - Route: Departing ${flight.departure}, arriving ${flight.arrival}
+          - Price: $${flight.price}
+          - Seat preference: ${seat}
+          - Date: ${flight.date}
+          - Destination: ${flight.destination}`,
+        maxTokens: 150,
+      });
+
+      yield* notify('Please confirm booking', 0.8)
+
+      // Second elicitation: Confirm booking
+      const confirmation = yield* elicitConfirmation();
+
+      if (confirmation.action !== 'accept' || !confirmation.content.confirmed) {
+        yield* log('info', 'User did not confirm booking')
+        return Err(new Error('not_confirmed'))
+      }
+
+      yield* notify('Creating booking...', 0.9)
+
+      // Return successful selection for after() phase
+      return ok({
+        flightId: selection.content.flightId,
+        seatPreference: selection.content.seatPreference,
+      })
+    }
+});
+
+function elicitConfirmation(summary) {
+  return elicit({
+    message: `${summary}\n\nConfirm this booking?`,
+    schema: z.object({
+      confirmed: z.boolean().describe('Confirm the booking'),
+    }),
+  })
+}
+
+function elicitFlightSelection({
+  flightOptions,
+  destination,
+  date,
+}: {
+  flightOptions: string;
+  destination: string;
+  date: string;
+}) {
+  // This function will return an operation which allows to yield* elicitFlightSelectinon()
+  return elicit({
+    message: `Available flights to ${destination} on ${date}:\n\n${flightOptions}\n\nSelect a flight and seat preference:`,
+    schema: z.object({
+      flightId: z.string().describe("Flight ID (e.g., FL001)"),
+      seatPreference: z
+        .enum(["window", "aisle", "middle"])
+        .describe("Seat preference"),
+    }),
+  });
+}**
+```
+

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -1,0 +1,348 @@
+# Elicit Use Cases
+
+This document describes key use cases for the elicit system, capturing design decisions and architectural implications.
+
+## 1. Multiple Agents Sharing Same Elicit
+
+**Scenario:** Multiple agents (e.g., Chat, Flight, Hotel) all need to elicit user input, and they share a common implementation (e.g., the same React UI component in a chat interface).
+
+**Behavior:**
+
+- Single implementation serves all agents — the UI has one `elicit` implementation that handles requests from any agent
+- Queueing by default — if multiple agents elicit concurrently, requests queue up
+- UI controls queue behavior — could show one at a time, stack them, or merge
+- Context flows through — coroutine context is available at invocation time, so the implementation can access agent identity, labels, and metadata for attribution/styling
+
+**Example:**
+
+```ts
+// Program level - one implementation serves all
+yield* ElicitProtocol.implement(chatUIElicit);
+
+// Any agent can call it
+const Chat = createAgent({
+  askQuestion: createTool("ask").execute(function* () {
+    yield* elicit({ message: "..." }); // uses shared impl
+  }),
+});
+
+const Flight = createAgent({
+  selectFlight: createTool("select").execute(function* () {
+    yield* elicit({ message: "..." }); // same shared impl
+  }),
+});
+```
+
+---
+
+## 2. Agent Asking User for Input via Chat
+
+**Scenario:** The "happy path" — agent is running, needs user input, sends an elicit that renders in the chat UI, user responds, agent continues.
+
+**Behavior:**
+
+- Typed elicit components — each elicit type has a schema (input/output) and a corresponding UI component
+- Calling coroutine suspends — the specific coroutine that called `yield* elicit(...)` is suspended; other coroutines can continue
+- User can go "off-script" — if user ignores the structured elicit and types something else, it returns `{ action: 'other', content: '...' }`
+
+**Handling "other" responses:**
+
+```ts
+yield* around({
+  *elicit([args], next) {
+    const result = yield* next(args);
+
+    if (result.action === "other") {
+      // Common handling: interpret via model
+      const interpretation = yield* sample({
+        prompt: `User responded with: "${result.content}"
+                 Expected: structured input for ${args.schema}
+                 What did they mean?`,
+      });
+      // Could re-elicit, transform result, etc.
+    }
+
+    return result;
+  },
+});
+```
+
+---
+
+## 3. MCP Invoking Tool Which Causes Elicit in Chat
+
+**Scenario:** An external MCP client (e.g., Claude Desktop) calls a tool exposed via MCP. That tool's execution triggers an elicit which renders in a chat UI and returns the result back through MCP.
+
+**Behavior:**
+
+- Transport bridges MCP and UI — the agent sits between MCP (tool invocation) and UI (elicit rendering)
+- MCP blocks on elicit — from the MCP client's perspective, the tool call is in-flight until the human completes the elicit
+- Agent code unchanged — the same tool code works whether invoked via MCP, HTTP, or directly
+
+**Architectural implication:**
+
+```ts
+// This tool works whether invoked via MCP, HTTP, or directly
+const Flight = createAgent({
+  bookFlight: createTool("book-flight").execute(function* () {
+    // Don't know/care if this came from MCP
+    const selection = yield* elicit({
+      message: "Select a flight",
+      schema: FlightSelectionSchema,
+    });
+    // Don't know/care that this rendered in a web chat UI
+    return Ok(selection.content);
+  }),
+});
+```
+
+---
+
+## 4. Elicit Location
+
+**Scenario:** The agent needs the user's location — accessing device GPS rather than asking them to type it.
+
+**Behavior:**
+
+- Device API access via elicit — a different category of elicit that accesses device capabilities
+- Distinct elicit type — has its own implementation that calls browser's geolocation API
+- Permission denial is an action — `{ action: 'denied' }`, not an error (consistent with expected outcomes vs. unexpected failures)
+
+**Framework-provided elicit type:**
+
+```ts
+import { createElicit } from "@sweatpants/agent";
+
+export const locationElicit = createElicit({
+  name: "location",
+  description: "Request user location from device GPS",
+  input: z.object({ accuracy: z.enum(["high", "low"]) }),
+  output: z.object({ lat: z.number(), lng: z.number() }),
+  actions: ["accept", "denied", "cancel"],
+});
+```
+
+**Usage:**
+
+```ts
+const location = yield* locationElicit({ accuracy: "high" });
+
+if (location.action === "denied") {
+  yield* notify("Location access was denied. Please enter your city manually.");
+  // Fall back to text input
+}
+```
+
+---
+
+## 5. Elicit Clipboard (Read and Write)
+
+**Scenario:** The agent wants to read from or write to the user's clipboard.
+
+**Behavior:**
+
+- Both read and write supported — two separate elicit types
+- Framework-provided — standard elicit types with documented schemas
+
+**Elicit types:**
+
+```ts
+export const clipboardWriteElicit = createElicit({
+  name: "clipboard-write",
+  description: "Copy text to user clipboard",
+  input: z.object({ text: z.string() }),
+  output: z.object({ success: z.boolean() }),
+  actions: ["accept", "denied"],
+});
+
+export const clipboardReadElicit = createElicit({
+  name: "clipboard-read",
+  description: "Read text from user clipboard",
+  input: z.object({}),
+  output: z.object({ text: z.string() }),
+  actions: ["accept", "denied", "cancel"],
+});
+```
+
+**Use cases:**
+
+- Write: Agent completed a booking → copies confirmation code to clipboard
+- Read: Agent asks "paste what you copied" → reads clipboard to process content
+
+---
+
+## 6. Elicit Draw a Card (Backend-Authoritative Interactions)
+
+**Scenario:** A card game or similar interaction where the backend controls state and the frontend presents.
+
+**Key insight:** This highlights the frontend-backend coordination pattern where the backend is authoritative.
+
+**Behavior:**
+
+- Backend controls state — what cards exist, which are available, validation
+- Frontend controls presentation — visual deck, animation, user interaction
+- System picks — the backend randomly selects, frontend just reveals/animates
+
+**Pattern:**
+
+```
+Backend (Agent)                         Frontend (UI)
+─────────────────                       ─────────────
+
+1. Agent has deck state
+2. Agent draws card (random)
+3. yield* elicit({
+     type: 'reveal-card',        ──────► 4. Receives card to reveal
+     card: { suit, value }               5. Animates card draw
+   })                                    6. User sees/acknowledges
+                            ◄──────────  7. Returns { action: 'accept' }
+8. Agent continues
+```
+
+**Architectural principle:** Not all elicits are "asking for input" — some are "presenting and waiting for acknowledgment" while the backend maintains authoritative state.
+
+**Security:** The backend never trusts the frontend for authoritative state. Validation, authorization, and state management always happen server-side.
+
+---
+
+## 7. Elicit Choice + Type Something
+
+**Scenario:** A compound elicit — user picks from options AND can type additional input. Common pattern: "Here are your options, or tell me something else."
+
+**Behavior:**
+
+- Single elicit, compound schema — one elicit type = one UI component
+- Explicit "custom input" option — distinct from `action: 'other'` (designed option vs. off-script)
+
+**Example:**
+
+```ts
+const choiceOrInputElicit = createElicit({
+  name: "choice-or-input",
+  description: "User selects from options or provides custom input",
+  input: z.object({
+    message: z.string(),
+    choices: z.array(
+      z.object({
+        label: z.string(),
+        value: z.string(),
+      })
+    ),
+  }),
+  output: z.discriminatedUnion("type", [
+    z.object({ type: z.literal("choice"), value: z.string() }),
+    z.object({ type: z.literal("custom"), text: z.string() }),
+  ]),
+});
+
+// Usage
+const result = yield* choiceOrInputElicit({
+  message: "How would you like to pay?",
+  choices: [
+    { label: "Credit Card", value: "cc" },
+    { label: "PayPal", value: "paypal" },
+    { label: "Bank Transfer", value: "bank" },
+  ],
+});
+
+if (result.action === "accept") {
+  if (result.content.type === "choice") {
+    // User picked an option
+  } else {
+    // User typed something custom
+  }
+}
+```
+
+**Distinction from `action: 'other'`:**
+
+| Scenario                              | How it's captured                                          |
+| ------------------------------------- | ---------------------------------------------------------- |
+| User picks from choices               | `{ action: 'accept', content: { type: 'choice', value } }` |
+| User types in the "other" field       | `{ action: 'accept', content: { type: 'custom', text } }`  |
+| User ignores elicit, types in chat    | `{ action: 'other', content: '...' }`                      |
+| User clicks X / dismisses             | `{ action: 'cancel' }`                                     |
+| User clicks "No thanks" button        | `{ action: 'decline' }`                                    |
+
+---
+
+## 8. Side Quest Without Losing Context
+
+**Scenario:** User is mid-flow with an agent, but wants to do something else temporarily (ask a different question, check something) then return to where they were.
+
+**Behavior:**
+
+- Coroutine tree, not stack — the suspended elicit is a node in a tree, not lost when user forks
+- Lossless return — when side quest completes, user returns to the exact pending state
+- Auto-return on completion — default behavior when side quest coroutine completes
+- Optional explicit navigation — power users can choose which pending context to return to
+
+**Pattern:**
+
+```
+Main flow                          Side quest
+──────────                         ──────────
+
+1. Agent asks about flight
+2. User selecting dates
+3. yield* elicit(dateSelection)
+        │
+        │ ◄── User: "Wait, what's the weather in Tokyo?"
+        │
+        ├─────────────────────────► 4. Fork: new coroutine
+        │ (suspended, not lost)        5. Weather agent responds
+        │                              6. User: "Ok thanks"
+        │                              7. Coroutine completes
+        │ ◄────────────────────────────┘
+        │
+        ▼ (resume exactly here)
+4. User completes date selection
+5. Agent continues booking
+```
+
+**Fork triggers:**
+
+- Explicit: User says "hold on" or clicks a "pause" action
+- Implicit: User starts talking about something different (system/agent detects tangent)
+
+**Nesting:** Forks can nest — side quest within a side quest forms a stack
+
+**UI representation:**
+
+```
+┌─────────────────────────────────────────────────┐
+│ Chat UI                                         │
+├─────────────────────────────────────────────────┤
+│ ┌─────────────────────────────────────────────┐ │
+│ │ Pending: Flight booking (selecting dates)   │ │ ◄── User can tap to return
+│ └─────────────────────────────────────────────┘ │
+│                                                 │
+│ Weather Agent: Tokyo will be 72°F next week... │
+│                                                 │
+│ [Type a message...]                             │
+└─────────────────────────────────────────────────┘
+```
+
+**Architectural requirements:**
+
+1. Serializable coroutine state — design for persistence from the start (required by 1.0)
+2. Context tree, not just stack — support both LIFO (default) and explicit navigation
+3. Fork/forward/back primitives — core capability shared with parent agents managing subagent state
+
+---
+
+## Cross-Cutting Themes
+
+These use cases reveal several architectural principles:
+
+1. **Protocol pattern** — Declaration (schema) separate from implementation (environment-specific)
+
+2. **Backend authoritative** — Validation, authorization, state management always server-side
+
+3. **Context flows through** — Coroutine context available at every point for attribution, middleware, etc.
+
+4. **Actions vs errors** — Expected outcomes (decline, cancel, denied, other) are actions, not exceptions
+
+5. **Serialization-ready** — Design for persistence from the start
+
+6. **Single implementation, multiple callers** — One elicit implementation serves all agents; queueing handles concurrency


### PR DESCRIPTION
Add documentation proposing an alternative API for defining agents that aligns with Effection's structured concurrency. Includes examples for:

PII redaction middleware to prevent leaking personal information
Context boundaries for scope-local HTTP retry configuration

[Proposal](https://github.com/taras/sweatpants/blob/tm/simplified-api-proposal/docs/simplified-agents-api.md)