### PR TITLE
Sampling exchange design docs

### DIFF
--- a/apps/yo-slides/package.json
+++ b/apps/yo-slides/package.json
@@ -8,7 +8,10 @@
     "export:mcp-native": "slidev export principal-engineers/mcp-native/slides.md --output mcp-native.pdf",
     "dev:effection": "slidev effection-team/structured-concurrency/slides.md --open",
     "build:effection": "slidev build effection-team/structured-concurrency/slides.md --out dist/effection",
-    "export:effection": "slidev export effection-team/structured-concurrency/slides.md --output effection.pdf"
+    "export:effection": "slidev export effection-team/structured-concurrency/slides.md --output effection.pdf",
+    "dev:fork-join": "slidev tech-leads/context-fork-join/slides.md --open",
+    "build:fork-join": "slidev build tech-leads/context-fork-join/slides.md --out dist/fork-join",
+    "export:fork-join": "slidev export tech-leads/context-fork-join/slides.md --output fork-join.pdf"
   },
   "dependencies": {
     "@slidev/cli": "^51.4.3",

--- a/apps/yo-slides/tech-leads/context-fork-join/slides.md
+++ b/apps/yo-slides/tech-leads/context-fork-join/slides.md
@@ -1,0 +1,169 @@
+---
+theme: default
+title: "Context is a Fork-Join Problem"
+info: |
+  ## Lessons from MCP tooling
+  Sweatpants Framework
+author: Grove Team
+keywords: mcp,context,architecture,tooling
+class: text-center
+highlighter: shiki
+drawings:
+  persist: false
+transition: slide-left
+mdc: true
+colorSchema: light
+---
+
+# Context is a Fork-Join Problem
+
+## What MCP taught us about deterministic flow
+
+<div class="pt-12">
+  <span class="px-2 py-1 rounded cursor-pointer bg-gray-100">
+    Sweatpants Framework
+  </span>
+</div>
+
+<div class="abs-br m-6 flex gap-2 text-sm opacity-50">
+  architecture | DX | adoption
+</div>
+
+---
+
+# The Problem We All Hit
+
+<v-clicks>
+
+**Context rot**: the model forgets, repeats, or hallucinates
+
+**Flow drift**: the model decides what to do next
+
+**Hidden coupling**: tools mutate context implicitly
+
+**Unbounded growth**: token budgets explode
+
+</v-clicks>
+
+---
+
+# The Mental Model
+
+Context is a flame chart of forks and joins.
+
+```mermaid {scale: 0.7}
+sequenceDiagram
+  participant P as Parent Context
+  participant T as Tool Fork
+
+  P->>T: tool entry (fork)
+  Note over T: tool work
+  T-->>P: tool result (join)
+```
+
+---
+
+# Forks Can Fork
+
+```mermaid {scale: 0.7}
+sequenceDiagram
+  participant P as Parent Context
+  participant T as Tool Fork
+  participant S as Sub-tool
+
+  P->>T: tool entry (fork)
+  Note over T: tool work
+  T->>S: sub-tool entry (fork)
+  Note over S: sub-tool work
+  S-->>T: sub-tool result (join)
+  T-->>P: tool result (join)
+```
+
+Each fork must join back to its parent.
+
+---
+
+# Micro-Loops
+
+"What is my purpose?" "You pass butter."
+
+```mermaid {scale: 0.45}
+sequenceDiagram
+  participant P as Parent
+  participant B as butter_bot
+  participant T as book_flight
+  participant L as LLM
+  participant U as User
+
+  P->>B: "Book a flight"
+  B->>T: { message: "Austin to Vegas" }
+  T->>L: sample("parse destination")
+  L-->>T: { from: "Austin", to: "Vegas" }
+  T->>U: elicit("When?")
+  U-->>T: "Friday"
+  T-->>B: { status: "done", ticket: "UA-1234" }
+  B-->>P: "Done! What else?"
+  P->>B: "Book a hotel"
+  B->>T: { message: "Book a hotel" }
+  T-->>B: { error: "I only book flights" }
+  B-->>P: "I can't do that. What else?"
+```
+
+<v-click>
+
+Elicits fork right to user. Samples fork right to LLM. All join back.
+
+</v-click>
+
+---
+
+# MCP Gives Us the Primitives
+
+MCP already encodes fork/join.
+
+- `tools/call` = fork into tool
+- `elicitation/create` = fork into user
+- `sampling/createMessage` = fork into LLM
+- `tool_result` = join back to parent
+
+---
+
+# The Business Takeaway
+
+## What is a ButterBot?
+
+A micro-chat with one purpose.
+
+- Controls a loop around a single tool
+- Passes messages, props, and history
+- Signals success or failure to the parent
+- "What else can I help with?"
+
+<v-click>
+
+ButterBot is shared vocabulary:
+
+| Engineering | Design | Business |
+|-------------|--------|----------|
+| fork-join flow | scoped interaction | predictable cost |
+
+</v-click>
+
+---
+
+# Closing
+
+Context is not a blob. It's a concurrency problem.
+
+<v-click>
+
+MCP gives us the fork/join primitives. Sweatpants shows the discipline.
+
+</v-click>
+
+
+<div class="mt-12 opacity-50 text-sm">
+
+context is a fork-join problem
+
+</div>

--- a/docs/mcp-alignment/DESIGN.md
+++ b/docs/mcp-alignment/DESIGN.md
@@ -1,0 +1,275 @@
+# MCP Spec Alignment - Design Document
+
+## Overview
+
+This document describes the design for aligning sweatpants with the MCP 2025-11-25 specification, including breaking changes to message format, adding the `__schema__` meta-tool pattern for structured output, and introducing `SampleExchange` for history accumulation.
+
+## Goals
+
+1. **Message format alignment** - Switch from OpenAI-style to MCP content blocks
+2. **URL elicitation guard** - Throw clear error if `mode: 'url'` is attempted
+3. **`__schema__` meta-tool pattern** - Convert `ctx.sample({ schema })` to a reserved tool
+4. **`SampleExchange` type** - Parallel to `ElicitExchange`, captures sampling as accumulate-able exchanges
+
+## Non-Goals
+
+1. **Handoff pattern changes** - Stays as-is (sweatpants invention, no MCP equivalent)
+2. **MCP Tasks integration** - Future work, not part of this change
+3. **Full URL elicitation support** - Just error handling for now
+
+---
+
+## MCP Standard vs Sweatpants Extensions
+
+### Standard MCP Features (`ctx.*`)
+
+| Feature | MCP Method | Notes |
+|---------|-----------|-------|
+| `ctx.sample()` | `sampling/createMessage` | Standard sampling |
+| `ctx.sample({ tools, toolChoice })` | `sampling/createMessage` | Tool calling in sampling (new in 2025-11-25) |
+| `ctx.elicit()` | `elicitation/create` | Form mode only |
+| `ctx.log()` | `notifications/message` | Standard logging |
+| `ctx.notify()` | `notifications/progress` | Standard progress |
+
+### Sweatpants Extensions
+
+| Feature | Description |
+|---------|-------------|
+| `ctx.branch()` | Structured concurrency (sub-branches) |
+| `ctx.sampleTools()` | Guaranteed tool calls with retry |
+| `ctx.sampleSchema()` | Guaranteed parsed output with retry |
+| `ctx.sample({ schema })` | Uses `__schema__` meta-tool pattern |
+| Keyed elicits | `.elicits({ key: schema })` - Type-safe UI bridging |
+| `ElicitExchange` | History accumulation for elicitation context |
+| `SampleExchange` | History accumulation for sampling context (new) |
+| Handoff pattern | `before/client/after` phases for tool execution |
+
+### Reserved Tool Names
+
+| Name | Purpose |
+|------|---------|
+| `__schema__` | Structured output meta-tool (clients implement per-provider) |
+
+---
+
+## Part 1: Message Format Alignment
+
+### Current Format (OpenAI-style)
+
+```typescript
+// Assistant with tool calls
+{ role: 'assistant', content: null, tool_calls: [{ id, type: 'function', function: { name, arguments } }] }
+
+// Tool result
+{ role: 'tool', tool_call_id: 'xxx', content: '...' }
+```
+
+### Target Format (MCP content blocks)
+
+```typescript
+// Assistant with tool use
+{ role: 'assistant', content: [{ type: 'tool_use', id: 'xxx', name: '...', input: {...} }] }
+
+// Tool result (in user message)
+{ role: 'user', content: [{ type: 'tool_result', toolUseId: 'xxx', content: [...] }] }
+```
+
+### Key Differences
+
+| Aspect | OpenAI Style | MCP Style |
+|--------|--------------|-----------|
+| Tool calls | `tool_calls` array on message | `tool_use` content blocks |
+| Tool results | `role: 'tool'` | `role: 'user'` with `tool_result` content |
+| Tool call ID | `tool_call_id` | `toolUseId` |
+
+---
+
+## Part 2: URL Elicitation Guard
+
+MCP 2025-11-25 introduces URL mode elicitation for sensitive data flows (OAuth, payments, etc.). Sweatpants does not currently support this.
+
+### Implementation
+
+Add validation in the elicitation encoder:
+
+```typescript
+export function encodeElicitationRequest(event, requestId) {
+  if ((event as any).mode === 'url') {
+    throw new Error(
+      'URL elicitation mode is not supported by sweatpants. ' +
+      'Use form mode (default) instead. ' +
+      'See: https://modelcontextprotocol.io/specification/2025-11-25/client/elicitation'
+    )
+  }
+  // ... rest of encoding
+}
+```
+
+---
+
+## Part 3: `__schema__` Meta-Tool Pattern
+
+### Problem
+
+MCP doesn't have a native `schema` parameter for sampling. Different providers implement structured output differently:
+
+- **OpenAI**: Native `response_format.json_schema` (streaming structured output)
+- **Anthropic**: Tool-calling workaround
+- **Ollama**: Native `format` parameter
+
+### Solution
+
+Use a reserved tool name `__schema__` that clients can implement optimally per provider.
+
+### Server Side (Tool Author)
+
+When `ctx.sample({ schema })` is called:
+
+1. Convert schema to `__schema__` tool
+2. Send sampling request with `tools: [__schema__]`, `toolChoice: 'required'`
+3. Receive response (tool_use with data in `input`)
+4. Extract, validate, and construct `SampleExchange`
+
+### Wire Format (MCP Compliant)
+
+**Request:**
+```typescript
+{
+  method: 'sampling/createMessage',
+  params: {
+    messages: [...],
+    tools: [{
+      name: '__schema__',
+      description: 'Respond with structured data matching this schema.',
+      inputSchema: { /* JSON Schema */ }
+    }],
+    toolChoice: { mode: 'required' }
+  }
+}
+```
+
+**Response (always 1 message over wire):**
+```typescript
+{
+  role: 'assistant',
+  content: [{
+    type: 'tool_use',
+    id: 'call_xxx',
+    name: '__schema__',
+    input: { /* parsed data */ }
+  }],
+  stopReason: 'toolUse'
+}
+```
+
+### Client Side (MCP Host)
+
+When a client sees `__schema__` in tools:
+
+- **Smart client (sweatpants)**: Use best provider implementation, return as tool_use
+- **Naive client**: Pass through as normal tool, model calls it, works anyway
+
+The server code works identically either way. The only difference is efficiency on the client side.
+
+---
+
+## Part 4: `SampleExchange` Type
+
+### Design Principles
+
+The exchange is a **representation of the interaction for context history**. It's not a pedantic record of what went over the wire. It models the data flow correctly so the context window makes sense.
+
+### Exchange Model
+
+An exchange is always conceptually `[request, response]`:
+
+- **Raw sampling**: `[userMessage, assistantMessage]` = 2 messages
+- **Structured output**: `[userMessage, assistantToolUse, toolResult]` = 3 messages
+
+For structured output, the "response" is split into 2 messages (tool_use + tool_result) to be MCP-compliant (tool_use MUST be followed by tool_result).
+
+### Type Definition
+
+```typescript
+interface SampleExchange<TParsed = undefined> {
+  /** The request message we sent */
+  request: McpMessage
+  
+  /** The assistant's response message */
+  response: McpMessage
+  
+  /** All messages for history accumulation (2 for raw, 3 for structured) */
+  messages: McpMessage[]
+  
+  /** Parsed structured data (only present when schema was used) */
+  parsed?: TParsed
+}
+```
+
+### Field Semantics
+
+| Field | Raw Sample | Structured Output |
+|-------|------------|-------------------|
+| `request` | User message | User message |
+| `response` | Assistant text message | Assistant tool_use message |
+| `messages` | `[request, response]` (2) | `[request, toolUse, toolResult]` (3) |
+| `parsed` | `undefined` | Extracted/validated data |
+
+### Consumer Patterns
+
+```typescript
+// Accumulate into history (most common)
+conversationHistory.push(...result.exchange.messages)
+
+// Get structured data
+const move = result.exchange.parsed
+
+// Edge case: only want request/response
+const { request, response } = result.exchange
+```
+
+### Comparison with ElicitExchange
+
+| Aspect | ElicitExchange | SampleExchange |
+|--------|----------------|----------------|
+| **Purpose** | Capture elicitation interaction | Capture sampling interaction |
+| **request** | Assistant's elicit tool_call | User message sent to model |
+| **response** | User's form response | Assistant's response |
+| **messages** | Always 2 | 2 (raw) or 3 (structured) |
+| **parsed** | Via `result.content` | Via `exchange.parsed` |
+
+---
+
+## Wire Format Summary
+
+### Raw Sampling
+
+```
+Request:  [user message]  →  sampling/createMessage
+Response: [assistant message]  ←  1 message over wire
+Exchange: [request, response]  =  2 messages for history
+```
+
+### Structured Output (`__schema__`)
+
+```
+Request:  [user message + __schema__ tool]  →  sampling/createMessage
+Response: [assistant tool_use]  ←  1 message over wire
+Exchange: [request, toolUse, toolResult]  =  3 messages for history
+          (we construct toolResult as ack)
+```
+
+---
+
+## Breaking Changes
+
+This is a **breaking change** affecting:
+
+1. **`ExtendedMessage` type** - Now uses MCP content blocks
+2. **`AssistantToolCallMessage`** - Removed, use `McpMessage` with `tool_use` content
+3. **`ToolResultMessage`** - Removed, use `McpMessage` with `tool_result` content
+4. **Exchange message format** - All exchanges use MCP format
+
+### Migration
+
+Users of `ExtendedMessage` will need to update their code to use MCP content block format instead of OpenAI-style `tool_calls` arrays.

--- a/docs/mcp-alignment/NOTES.md
+++ b/docs/mcp-alignment/NOTES.md
@@ -1,0 +1,259 @@
+# MCP Spec Alignment - Context Notes
+
+This document captures the full context of our design discussion for future reference.
+
+---
+
+## Background: MCP 2025-11-25 Spec Changes
+
+The MCP specification (2025-11-25) introduced several features that affect our design:
+
+### Tools in Sampling
+
+The spec now supports tools in `sampling/createMessage`:
+
+```typescript
+interface CreateMessageRequestParams {
+  messages: SamplingMessage[]
+  tools?: Tool[]           // NEW in 2025-11-25
+  toolChoice?: ToolChoice  // NEW in 2025-11-25
+  // ...
+}
+```
+
+Clients declare support via `sampling.tools` capability.
+
+### Message Content Blocks
+
+MCP uses content blocks instead of OpenAI-style message format:
+
+- `ToolUseContent` - Assistant requesting a tool call
+- `ToolResultContent` - Result provided back to assistant
+
+Key constraint from spec:
+> every assistant message containing `ToolUseContent` blocks **MUST** be followed by a user message that consists entirely of `ToolResultContent` blocks
+
+### Elicitation Modes
+
+MCP 2025-11-25 adds URL mode elicitation for sensitive data:
+- `mode: 'form'` - Standard form-based elicitation
+- `mode: 'url'` - Redirect to URL for sensitive interactions (OAuth, payments)
+
+Sweatpants does not support URL mode - we'll throw an error if attempted.
+
+---
+
+## Key Design Decisions
+
+### 1. Message Format: MCP Content Blocks
+
+**Decision**: Switch from OpenAI-style to MCP content blocks.
+
+**Rationale**: 
+- Align with MCP spec
+- Single format throughout the codebase
+- Breaking change is acceptable
+
+**Before (OpenAI-style)**:
+```typescript
+{ role: 'assistant', content: null, tool_calls: [...] }
+{ role: 'tool', tool_call_id: 'xxx', content: '...' }
+```
+
+**After (MCP-style)**:
+```typescript
+{ role: 'assistant', content: [{ type: 'tool_use', ... }] }
+{ role: 'user', content: [{ type: 'tool_result', ... }] }
+```
+
+### 2. Structured Output: `__schema__` Meta-Tool
+
+**Decision**: Use a reserved tool name `__schema__` for structured output.
+
+**Rationale**:
+- MCP doesn't have native schema support
+- Different providers implement structured output differently
+- Using a tool is the "lowest common denominator" that always works
+- Smart clients can intercept `__schema__` and use native provider features
+- Dunder naming (`__schema__`) prevents collision with user tools
+
+**How it works**:
+1. Server sends `tools: [{ name: '__schema__', inputSchema }]`
+2. Client either:
+   - Uses native structured output (OpenAI, Ollama) and packages as tool_use
+   - Falls through to normal tool calling (works with any client)
+3. Server receives tool_use with data in `input` field
+4. Server extracts and validates the data
+
+### 3. Exchange Model: Representing Data Flow
+
+**Decision**: Exchanges represent **data flow**, not pedantic wire reality.
+
+**Key insight**: The exchange is faked/constructed to correctly represent the interaction for context history purposes.
+
+**Raw sampling**:
+- Wire: 1 message (assistant response)
+- Exchange: `[request, response]` = 2 messages
+
+**Structured output**:
+- Wire: 1 message (assistant tool_use)
+- Exchange: `[request, toolUse, toolResult]` = 3 messages
+- We construct the `toolResult` as acknowledgment
+
+**Why 3 messages for structured output**:
+- MCP requires tool_use to be followed by tool_result
+- If you accumulate just `[request, toolUse]`, the context is malformed
+- The 3-message form is "closed" and ready for accumulation
+
+### 4. `SampleExchange` Type Design
+
+**Decision**: Simple, flexible type with `request`, `response`, `messages`, `parsed`.
+
+```typescript
+interface SampleExchange<TParsed = undefined> {
+  request: McpMessage
+  response: McpMessage
+  messages: McpMessage[]  // Just an array, not union type
+  parsed?: TParsed
+}
+```
+
+**Rationale**:
+- `request` and `response` allow edge case handling
+- `messages` is what you spread into history (most common use)
+- `parsed` is the structured data (when schema was used)
+- Not over-engineering the types - `messages` is just an array
+
+**Consumer patterns**:
+```typescript
+// Most common: accumulate into history
+conversationHistory.push(...result.exchange.messages)
+
+// Get structured data
+const move = result.exchange.parsed
+
+// Edge case: custom handling
+const { request, response } = result.exchange
+```
+
+### 5. Handoff Pattern: Stays As-Is
+
+**Decision**: The handoff pattern (`before/client/after`) is a sweatpants invention and has no MCP equivalent.
+
+**Context**: We explored whether MCP Tasks (new in 2025-11-25) relates to handoff:
+- MCP Tasks = async/deferred execution with polling
+- Handoff = structured execution phases for client interaction
+
+They solve different problems and could work together (a handoff tool could be a Task), but handoff is purely a sweatpants application-level pattern.
+
+---
+
+## Wire Format Details
+
+### Sampling Request
+
+```typescript
+{
+  jsonrpc: '2.0',
+  id: 1,
+  method: 'sampling/createMessage',
+  params: {
+    messages: [{ role: 'user', content: [{ type: 'text', text: '...' }] }],
+    tools: [{ name: '__schema__', inputSchema: {...} }],  // For structured output
+    toolChoice: { mode: 'required' },                      // For structured output
+    maxTokens: 4096
+  }
+}
+```
+
+### Sampling Response (Always 1 Message)
+
+```typescript
+{
+  jsonrpc: '2.0',
+  id: 1,
+  result: {
+    role: 'assistant',
+    content: [{ type: 'tool_use', id: 'xxx', name: '__schema__', input: {...} }],
+    model: 'claude-3-sonnet',
+    stopReason: 'toolUse'
+  }
+}
+```
+
+### Constructed Exchange (3 Messages for Structured Output)
+
+```typescript
+[
+  // 1. Request (what we sent)
+  { role: 'user', content: [{ type: 'text', text: 'Pick your move' }] },
+  
+  // 2. Response (assistant's tool_use - from wire)
+  { role: 'assistant', content: [{ type: 'tool_use', id: 'xxx', name: '__schema__', input: {...} }] },
+  
+  // 3. Ack (we construct this)
+  { role: 'user', content: [{ type: 'tool_result', toolUseId: 'xxx', content: [{ type: 'text', text: 'ok' }] }] }
+]
+```
+
+---
+
+## Token Efficiency Consideration
+
+**Problem**: If we echo the tool call args into the tool_result, that duplicates tokens.
+
+**Solution**: Use minimal acknowledgment in tool_result:
+```typescript
+{ type: 'tool_result', toolUseId: 'xxx', content: [{ type: 'text', text: 'ok' }] }
+```
+
+The data only appears once (in the tool_use `input`), not duplicated.
+
+---
+
+## Comparison: ElicitExchange vs SampleExchange
+
+| Aspect | ElicitExchange | SampleExchange |
+|--------|----------------|----------------|
+| **Trigger** | `ctx.elicit()` | `ctx.sample()` |
+| **Direction** | Server → User → Server | Server → Model → Server |
+| **request** | Assistant's elicit tool_call | User message to model |
+| **response** | User's form response | Assistant's response |
+| **messages** | Always 2 | 2 (raw) or 3 (structured) |
+| **parsed** | Via `result.content` | Via `exchange.parsed` |
+| **context** | Captured from elicit args | N/A |
+| **withArguments** | Transform context for history | N/A |
+
+---
+
+## Files Affected Summary
+
+### Core Changes
+- `mcp-tool-types.ts` - Types, `SampleExchange`
+- `protocol/message-encoder.ts` - Encoding, URL guard
+- `protocol/message-decoder.ts` - Decoding
+- `bridge-runtime.ts` - `__schema__`, exchanges
+- `branch-runtime.ts` - Same as bridge
+
+### Supporting Changes
+- `session/worker-runner.ts`
+- `handler/session-manager.ts`
+- `plugin-tool-executor.ts`
+- `plugin-session-manager.ts`
+
+### Tests
+- All tests asserting on message format
+- Structured output tests
+
+### Apps
+- `tictactoe/tool.ts` - Uses `ExtendedMessage`
+
+---
+
+## Open Questions (Resolved)
+
+1. **Message format alignment** - Clean break, no deprecation ✓
+2. **`__schema__` naming** - Dunder convention to avoid collision ✓
+3. **Schema result extraction** - Extract from `toolUse.input`, validate, include in exchange ✓
+4. **Exchange type complexity** - Keep simple: `messages: McpMessage[]` ✓
+5. **Token duplication** - Minimal "ok" ack, no data echo ✓

--- a/docs/mcp-alignment/PROGRESS.md
+++ b/docs/mcp-alignment/PROGRESS.md
@@ -1,0 +1,118 @@
+# MCP Spec Alignment - Implementation Progress
+
+## Status: Planning Complete
+
+Last Updated: 2025-01-16
+
+---
+
+## Phases
+
+### Phase 1: Core Type Changes
+- [ ] Update `McpMessage` and content block types in `protocol/types.ts`
+- [ ] Remove `AssistantToolCallMessage`, `ToolResultMessage`, `ToolCall` from `mcp-tool-types.ts`
+- [ ] Update `ExtendedMessage` to use `McpMessage`
+- [ ] Add `SampleExchange` type
+- [ ] Update `ElicitExchange` to use MCP format
+
+### Phase 2: Protocol Layer
+- [ ] Update `message-encoder.ts` - encode tool_use/tool_result content blocks
+- [ ] Update `message-encoder.ts` - add URL elicitation guard
+- [ ] Update `message-encoder.ts` - remove `metadata.responseSchema` path
+- [ ] Update `message-decoder.ts` - decode tool_use/tool_result content blocks
+
+### Phase 3: Runtime Layer
+- [ ] Update `bridge-runtime.ts` - `__schema__` transformation
+- [ ] Update `bridge-runtime.ts` - `SampleExchange` construction
+- [ ] Update `bridge-runtime.ts` - `ElicitExchange` to MCP format
+- [ ] Update `branch-runtime.ts` - same changes as bridge-runtime
+- [ ] Update `session/worker-runner.ts` - message format
+- [ ] Update `handler/session-manager.ts` - message format
+
+### Phase 4: Plugin/Handler Layer
+- [ ] Update `handler/durable/plugin-tool-executor.ts`
+- [ ] Update `handler/durable/plugin-session-manager.ts`
+
+### Phase 5: Re-exports
+- [ ] Update `mcp-tools/types.ts`
+- [ ] Update `lib/chat/index.ts`
+
+### Phase 6: Tests
+- [ ] Update `__tests__/bridge-runtime.test.ts`
+- [ ] Update `protocol/__tests__/protocol.test.ts`
+- [ ] Update `__tests__/sampling-structured.test.ts`
+- [ ] Update other affected test files
+
+### Phase 7: Apps
+- [ ] Update `apps/yo-chat/src/tools/tictactoe/tool.ts`
+- [ ] Verify all apps compile and tests pass
+
+### Phase 8: Documentation
+- [ ] Add inline documentation to types
+- [ ] Update any existing docs
+
+---
+
+## Files to Change
+
+### Package: `packages/framework/src/lib/chat/mcp-tools/`
+
+| File | Status | Changes |
+|------|--------|---------|
+| `mcp-tool-types.ts` | ⬜ | Update types, add `SampleExchange`, add docs |
+| `protocol/types.ts` | ⬜ | Already has MCP types ✓ |
+| `protocol/message-encoder.ts` | ⬜ | URL guard, message encoding, remove schema metadata |
+| `protocol/message-decoder.ts` | ⬜ | Handle tool_use/tool_result content blocks |
+| `bridge-runtime.ts` | ⬜ | `__schema__`, `SampleExchange`, message format |
+| `branch-runtime.ts` | ⬜ | Same as bridge-runtime |
+| `session/types.ts` | ⬜ | May need updates |
+| `session/worker-runner.ts` | ⬜ | Message format |
+| `handler/session-manager.ts` | ⬜ | Message format |
+| `types.ts` | ⬜ | Update re-exports |
+
+### Package: `packages/framework/src/lib/chat/`
+
+| File | Status | Changes |
+|------|--------|---------|
+| `index.ts` | ⬜ | Update re-exports |
+
+### Package: `packages/framework/src/handler/durable/`
+
+| File | Status | Changes |
+|------|--------|---------|
+| `plugin-tool-executor.ts` | ⬜ | ExtendedMessage handling |
+| `plugin-session-manager.ts` | ⬜ | tool_calls handling |
+
+### Tests
+
+| File | Status | Changes |
+|------|--------|---------|
+| `__tests__/bridge-runtime.test.ts` | ⬜ | Message format assertions |
+| `protocol/__tests__/protocol.test.ts` | ⬜ | Encoding/decoding tests |
+| `__tests__/sampling-structured.test.ts` | ⬜ | Schema sampling tests |
+| Other test files | ⬜ | TBD based on failures |
+
+### Apps
+
+| File | Status | Changes |
+|------|--------|---------|
+| `apps/yo-chat/src/tools/tictactoe/tool.ts` | ⬜ | ExtendedMessage usage |
+
+---
+
+## Verification Checklist
+
+- [ ] All TypeScript compiles without errors
+- [ ] All unit tests pass
+- [ ] All e2e tests pass
+- [ ] Manual testing with yo-chat app
+- [ ] Manual testing with yo-mcp app
+
+---
+
+## Notes
+
+- This is a breaking change - no deprecation warnings, clean break
+- The `__schema__` tool name uses dunder convention to avoid collision with user tools
+- Wire format is always MCP-compliant
+- Exchanges are "faked" to represent correct data flow for context history

--- a/packages/framework/src/handler/durable/plugin-session-manager.ts
+++ b/packages/framework/src/handler/durable/plugin-session-manager.ts
@@ -54,9 +54,9 @@ import type {
   ToolSessionStatus,
   SampleRequestEvent,
   ToolSessionRegistry,
-  SampleResultBase,
-  SampleResultWithParsed,
-  SampleResultWithToolCalls,
+  RawSampleResultBase,
+  RawSampleResultWithParsed,
+  RawSampleResultWithToolCalls,
 } from '../../lib/chat/mcp-tools/session/types.ts'
 // Note: createToolSessionRegistry should be called at server startup, not here
 // import { createToolSessionRegistry } from '../../lib/chat/mcp-tools/session/session-registry.ts'
@@ -401,7 +401,7 @@ export function createPluginSessionManager(
                   const responseText = chatResult?.text ?? fullText
 
                   // Determine response type and build result
-                  let result: SampleResultBase | SampleResultWithParsed<unknown> | SampleResultWithToolCalls
+                  let result: RawSampleResultBase | RawSampleResultWithParsed<unknown> | RawSampleResultWithToolCalls
 
                   if (toolCalls.length > 0) {
                     // Tool calling response

--- a/packages/framework/src/lib/chat/index.ts
+++ b/packages/framework/src/lib/chat/index.ts
@@ -26,11 +26,17 @@ export type {
   SamplingToolCall,
   SamplingToolDefinition,
   SamplingToolChoice,
-  // Extended message types for conversation history with tool interactions
+  // Extended message type for conversation history
   ExtendedMessage,
-  AssistantToolCallMessage,
-  ToolResultMessage,
-  ToolCall,
+  // MCP message types for tool interactions
+  McpMessage,
+  McpContentBlock,
+  McpTextContent,
+  McpToolUseContent,
+  McpToolResultContent,
+  // Exchange types for history accumulation
+  ElicitExchange,
+  SampleExchange,
 } from './mcp-tools/mcp-tool-types.ts'
 
 // Plugin builder (browser-safe)

--- a/packages/framework/src/lib/chat/mcp-tools/__tests__/branch.test.ts
+++ b/packages/framework/src/lib/chat/mcp-tools/__tests__/branch.test.ts
@@ -201,7 +201,9 @@ describe('runBranchTool - elicitation', () => {
       return result
     })
 
-    expect(result).toEqual({ action: 'accept', content: { choice: 'A' } })
+    expect(result).toMatchObject({ action: 'accept', content: { choice: 'A' } })
+    // Exchange should be present on accepted result
+    expect((result as any).exchange).toBeDefined()
   })
 
   it('handles decline response', async () => {

--- a/packages/framework/src/lib/chat/mcp-tools/__tests__/mcp-alignment.test.ts
+++ b/packages/framework/src/lib/chat/mcp-tools/__tests__/mcp-alignment.test.ts
@@ -1,0 +1,379 @@
+/**
+ * MCP Spec Alignment Tests
+ *
+ * Tests for the MCP 2025-11-25 spec alignment changes:
+ * 1. __schema__ meta-tool encoding pattern
+ * 2. SampleExchange message counts (2 for raw, 3 for structured)
+ * 3. URL elicitation guard
+ * 4. createRawSampleExchange / createStructuredSampleExchange helpers
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  encodeSamplingRequest,
+  encodeElicitationRequest,
+  SCHEMA_TOOL_NAME,
+} from '../protocol/message-encoder.ts'
+import {
+  createRawSampleExchange,
+  createStructuredSampleExchange,
+} from '../mcp-tool-types.ts'
+import type {
+  SampleRequestEvent,
+  ElicitRequestEvent,
+} from '../session/types.ts'
+
+// =============================================================================
+// __SCHEMA__ META-TOOL ENCODING
+// =============================================================================
+
+describe('__schema__ meta-tool encoding', () => {
+  it('should transform schema into __schema__ tool', () => {
+    const event: SampleRequestEvent = {
+      type: 'sample_request',
+      lsn: 1,
+      timestamp: Date.now(),
+      sampleId: 'sample_1',
+      messages: [{ role: 'user', content: 'Pick a cell' }],
+      schema: {
+        type: 'object',
+        properties: {
+          cell: { type: 'number', minimum: 0, maximum: 8 },
+        },
+        required: ['cell'],
+      },
+    }
+
+    const request = encodeSamplingRequest(event, 'req_1')
+
+    // Should have tools array with __schema__ first
+    expect(request.params?.tools).toBeDefined()
+    expect(request.params?.tools).toHaveLength(1)
+    expect(request.params?.tools?.[0]?.name).toBe(SCHEMA_TOOL_NAME)
+    expect(request.params?.tools?.[0]?.description).toBe(
+      'Respond with structured data matching this schema.'
+    )
+    expect(request.params?.tools?.[0]?.inputSchema).toEqual(event.schema)
+
+    // Should force tool choice to required
+    expect(request.params?.toolChoice).toEqual({ mode: 'required' })
+  })
+
+  it('should prepend __schema__ to existing tools', () => {
+    const event: SampleRequestEvent = {
+      type: 'sample_request',
+      lsn: 1,
+      timestamp: Date.now(),
+      sampleId: 'sample_1',
+      messages: [{ role: 'user', content: 'Pick a strategy' }],
+      schema: { type: 'object', properties: { choice: { type: 'string' } } },
+      tools: [
+        { name: 'offensive', inputSchema: { type: 'object' } },
+        { name: 'defensive', inputSchema: { type: 'object' } },
+      ],
+    }
+
+    const request = encodeSamplingRequest(event, 'req_1')
+
+    // Should have __schema__ first, then existing tools
+    expect(request.params?.tools).toHaveLength(3)
+    expect(request.params?.tools?.[0]?.name).toBe(SCHEMA_TOOL_NAME)
+    expect(request.params?.tools?.[1]?.name).toBe('offensive')
+    expect(request.params?.tools?.[2]?.name).toBe('defensive')
+  })
+
+  it('should not add __schema__ when no schema provided', () => {
+    const event: SampleRequestEvent = {
+      type: 'sample_request',
+      lsn: 1,
+      timestamp: Date.now(),
+      sampleId: 'sample_1',
+      messages: [{ role: 'user', content: 'Hello' }],
+    }
+
+    const request = encodeSamplingRequest(event, 'req_1')
+
+    expect(request.params?.tools).toBeUndefined()
+    expect(request.params?.toolChoice).toBeUndefined()
+  })
+
+  it('should pass through tools without schema', () => {
+    const event: SampleRequestEvent = {
+      type: 'sample_request',
+      lsn: 1,
+      timestamp: Date.now(),
+      sampleId: 'sample_1',
+      messages: [{ role: 'user', content: 'Pick' }],
+      tools: [{ name: 'pick', inputSchema: { type: 'object' } }],
+      toolChoice: 'auto',
+    }
+
+    const request = encodeSamplingRequest(event, 'req_1')
+
+    expect(request.params?.tools).toHaveLength(1)
+    expect(request.params?.tools?.[0]?.name).toBe('pick')
+    expect(request.params?.toolChoice).toEqual({ mode: 'auto' })
+  })
+})
+
+// =============================================================================
+// SAMPLE EXCHANGE HELPERS
+// =============================================================================
+
+describe('SampleExchange helpers', () => {
+  describe('createRawSampleExchange', () => {
+    it('should create 2-message exchange for raw sampling', () => {
+      const exchange = createRawSampleExchange(
+        'What is the weather?',
+        'The weather is sunny and 72F.'
+      )
+
+      // Should have 2 messages
+      expect(exchange.messages).toHaveLength(2)
+
+      // Request should be user message
+      expect(exchange.request.role).toBe('user')
+      expect(exchange.request.content).toEqual([
+        { type: 'text', text: 'What is the weather?' },
+      ])
+
+      // Response should be assistant message
+      expect(exchange.response.role).toBe('assistant')
+      expect(exchange.response.content).toEqual([
+        { type: 'text', text: 'The weather is sunny and 72F.' },
+      ])
+
+      // Messages should be [request, response]
+      expect(exchange.messages[0]).toBe(exchange.request)
+      expect(exchange.messages[1]).toBe(exchange.response)
+
+      // Parsed should be undefined
+      expect(exchange.parsed).toBeUndefined()
+    })
+
+    it('should handle empty strings', () => {
+      const exchange = createRawSampleExchange('', '')
+
+      expect(exchange.messages).toHaveLength(2)
+      expect(exchange.request.content).toEqual([{ type: 'text', text: '' }])
+      expect(exchange.response.content).toEqual([{ type: 'text', text: '' }])
+    })
+  })
+
+  describe('createStructuredSampleExchange', () => {
+    it('should create 3-message exchange for structured output', () => {
+      const parsed = { cell: 4, reason: 'center strategy' }
+      const exchange = createStructuredSampleExchange(
+        'Pick a cell (0-8)',
+        parsed,
+        'call_abc123'
+      )
+
+      // Should have 3 messages
+      expect(exchange.messages).toHaveLength(3)
+
+      // Request should be user message
+      expect(exchange.request.role).toBe('user')
+      expect(exchange.request.content).toEqual([
+        { type: 'text', text: 'Pick a cell (0-8)' },
+      ])
+
+      // Response should be assistant with tool_use
+      expect(exchange.response.role).toBe('assistant')
+      expect(exchange.response.content).toEqual([
+        {
+          type: 'tool_use',
+          id: 'call_abc123',
+          name: '__schema__',
+          input: {},
+        },
+      ])
+
+      // Third message should be tool_result with echoed parsed data
+      const toolResult = exchange.messages[2]
+      expect(toolResult?.role).toBe('user')
+      expect(toolResult?.content).toEqual([
+        {
+          type: 'tool_result',
+          toolUseId: 'call_abc123',
+          content: [{ type: 'text', text: JSON.stringify(parsed) }],
+        },
+      ])
+
+      // Parsed should be the typed data
+      expect(exchange.parsed).toEqual(parsed)
+    })
+
+    it('should preserve complex nested parsed data', () => {
+      const parsed = {
+        move: { cell: 4, confidence: 0.95 },
+        alternatives: [{ cell: 0 }, { cell: 8 }],
+      }
+      const exchange = createStructuredSampleExchange(
+        'Analyze the board',
+        parsed,
+        'call_xyz'
+      )
+
+      expect(exchange.parsed).toEqual(parsed)
+      // The input in tool_use should be blank
+      const content = exchange.response.content
+      const toolUse = Array.isArray(content) ? content[0] : content
+      expect(toolUse).toHaveProperty('input')
+      expect((toolUse as { input: Record<string, unknown> }).input).toEqual({})
+    })
+
+    it('should handle null parsed value', () => {
+    const exchange = createStructuredSampleExchange(
+      'Try something',
+      null,
+      'call_null'
+    )
+
+    expect(exchange.parsed).toBeNull()
+    expect(exchange.messages).toHaveLength(3)
+
+    const toolResult = exchange.messages[2]
+    const toolResultContent = Array.isArray(toolResult?.content)
+      ? toolResult?.content[0]
+      : toolResult?.content
+    expect(toolResultContent).toHaveProperty('content')
+    expect((toolResultContent as { content: Array<{ text: string }> }).content[0]?.text).toBe('null')
+  })
+  })
+})
+
+// =============================================================================
+// URL ELICITATION GUARD
+// =============================================================================
+
+describe('URL elicitation guard', () => {
+  it('should throw error when mode is url', () => {
+    const event = {
+      type: 'elicit_request' as const,
+      lsn: 1,
+      timestamp: Date.now(),
+      elicitId: 'elicit_1',
+      key: 'oauth',
+      message: 'Please authorize',
+      schema: { type: 'object' },
+      mode: 'url', // This is the problematic mode
+    } as ElicitRequestEvent & { mode?: string }
+
+    expect(() => encodeElicitationRequest(event, 'req_1')).toThrow(
+      'URL elicitation mode is not supported by sweatpants'
+    )
+  })
+
+  it('should include helpful error message with spec link', () => {
+    const event = {
+      type: 'elicit_request' as const,
+      lsn: 1,
+      timestamp: Date.now(),
+      elicitId: 'elicit_1',
+      key: 'oauth',
+      message: 'Please authorize',
+      schema: { type: 'object' },
+      mode: 'url',
+    } as ElicitRequestEvent & { mode?: string }
+
+    expect(() => encodeElicitationRequest(event, 'req_1')).toThrow(
+      /https:\/\/modelcontextprotocol\.io\/specification/
+    )
+  })
+
+  it('should work normally with form mode (explicit)', () => {
+    const event = {
+      type: 'elicit_request' as const,
+      lsn: 1,
+      timestamp: Date.now(),
+      elicitId: 'elicit_1',
+      key: 'confirm',
+      message: 'Please confirm',
+      schema: { type: 'object', properties: { ok: { type: 'boolean' } } },
+      mode: 'form',
+    } as ElicitRequestEvent & { mode?: string }
+
+    const request = encodeElicitationRequest(event, 'req_1')
+
+    expect(request.params?.mode).toBe('form')
+    expect(request.params?.message).toBe('Please confirm')
+  })
+
+  it('should work normally without mode (defaults to form)', () => {
+    const event: ElicitRequestEvent = {
+      type: 'elicit_request',
+      lsn: 1,
+      timestamp: Date.now(),
+      elicitId: 'elicit_1',
+      key: 'confirm',
+      message: 'Please confirm',
+      schema: { type: 'object', properties: { ok: { type: 'boolean' } } },
+    }
+
+    const request = encodeElicitationRequest(event, 'req_1')
+
+    expect(request.params?.mode).toBe('form')
+  })
+})
+
+// =============================================================================
+// EXCHANGE MESSAGE COUNT CONSISTENCY
+// =============================================================================
+
+describe('Exchange message count consistency', () => {
+  it('raw sample exchange always has exactly 2 messages', () => {
+    const testCases = [
+      { prompt: 'Short', response: 'Short reply' },
+      { prompt: 'A'.repeat(1000), response: 'B'.repeat(2000) },
+      { prompt: '', response: '' },
+      { prompt: 'With\nnewlines', response: 'Also\nhas\nnewlines' },
+    ]
+
+    for (const { prompt, response } of testCases) {
+      const exchange = createRawSampleExchange(prompt, response)
+      expect(exchange.messages).toHaveLength(2)
+      expect(exchange.messages[0]?.role).toBe('user')
+      expect(exchange.messages[1]?.role).toBe('assistant')
+    }
+  })
+
+  it('structured sample exchange always has exactly 3 messages', () => {
+    const testCases = [
+      { prompt: 'Pick', parsed: { cell: 0 }, id: 'call_1' },
+      { prompt: 'Complex', parsed: { a: { b: { c: 1 } } }, id: 'call_2' },
+      { prompt: 'Array', parsed: [1, 2, 3], id: 'call_3' },
+      { prompt: 'Null', parsed: null, id: 'call_4' },
+    ]
+
+    for (const { prompt, parsed, id } of testCases) {
+      const exchange = createStructuredSampleExchange(prompt, parsed, id)
+      expect(exchange.messages).toHaveLength(3)
+      expect(exchange.messages[0]?.role).toBe('user')
+      expect(exchange.messages[1]?.role).toBe('assistant')
+      expect(exchange.messages[2]?.role).toBe('user') // tool_result is in user message
+    }
+  })
+
+  it('structured exchange tool_result references correct tool_use id', () => {
+    const exchange = createStructuredSampleExchange(
+      'Pick a move',
+      { cell: 4 },
+      'unique_call_id_123'
+    )
+
+    // Get tool_use id from response
+    const responseContent = exchange.response.content
+    const toolUse = Array.isArray(responseContent) ? responseContent[0] : responseContent
+    expect(toolUse).toHaveProperty('id', 'unique_call_id_123')
+
+    // Get tool_result toolUseId from third message
+    const thirdMsg = exchange.messages[2]
+    const thirdMsgContent = thirdMsg?.content
+    const toolResult = Array.isArray(thirdMsgContent) ? thirdMsgContent[0] : thirdMsgContent
+    expect(toolResult).toHaveProperty('toolUseId', 'unique_call_id_123')
+
+    // Tool_result content should echo parsed data
+    const toolResultContent = (toolResult as { content: Array<{ text: string }> }).content[0]
+    expect(toolResultContent?.text).toBe(JSON.stringify({ cell: 4 }))
+  })
+})

--- a/packages/framework/src/lib/chat/mcp-tools/branch-runtime.ts
+++ b/packages/framework/src/lib/chat/mcp-tools/branch-runtime.ts
@@ -320,7 +320,7 @@ function createBranchContext(
       
       return {
         *[Symbol.iterator]() {
-          let lastResult: SampleResultBase | SampleResultWithToolCalls | undefined
+          let lastResult: SampleResultBase | SampleResultWithToolCalls | SampleResultWithParsed<unknown> | undefined
           
           for (let attempt = 0; attempt <= maxRetries; attempt++) {
             // Build the sample config

--- a/packages/framework/src/lib/chat/mcp-tools/handler/session-manager.ts
+++ b/packages/framework/src/lib/chat/mcp-tools/handler/session-manager.ts
@@ -38,25 +38,27 @@ import type { JsonRpcId } from '../protocol/types.ts'
  * The session-manager doesn't have access to the original elicit context,
  * so we create a minimal placeholder. The actual context is captured in
  * the bridge-runtime where the elicit originates.
+ * 
+ * Uses MCP content block format.
  */
 function createPlaceholderExchange(content: unknown): ElicitExchange<unknown> {
   const placeholderToolCallId = 'placeholder'
   const request = {
     role: 'assistant' as const,
-    content: null,
-    tool_calls: [{
+    content: [{
+      type: 'tool_use' as const,
       id: placeholderToolCallId,
-      type: 'function' as const,
-      function: {
-        name: 'elicit',
-        arguments: {},
-      },
+      name: 'elicit',
+      input: {},
     }],
   }
   const response = {
-    role: 'tool' as const,
-    tool_call_id: placeholderToolCallId,
-    content: JSON.stringify(content),
+    role: 'user' as const,
+    content: [{
+      type: 'tool_result' as const,
+      toolUseId: placeholderToolCallId,
+      content: [{ type: 'text' as const, text: JSON.stringify(content) }],
+    }],
   }
   return {
     context: {},

--- a/packages/framework/src/lib/chat/mcp-tools/handler/session-manager.ts
+++ b/packages/framework/src/lib/chat/mcp-tools/handler/session-manager.ts
@@ -16,7 +16,7 @@
 import { createContext, type Operation } from 'effection'
 import type { ToolSessionRegistry } from '../session/types.ts'
 import type { FinalizedMcpToolWithElicits } from '../mcp-tool-builder.ts'
-import type { ElicitsMap, ElicitResult, ElicitExchange, SampleResult } from '../mcp-tool-types.ts'
+import type { ElicitsMap, ElicitResult, ElicitExchange, RawSampleResultBase } from '../mcp-tool-types.ts'
 import type {
   McpSessionState,
   PendingElicitation,
@@ -49,6 +49,7 @@ function createPlaceholderExchange(content: unknown): ElicitExchange<unknown> {
       type: 'tool_use' as const,
       id: placeholderToolCallId,
       name: 'elicit',
+      // Keep input empty; echo data in tool_result for history
       input: {},
     }],
   }
@@ -386,7 +387,7 @@ export class McpSessionManager {
       textContent = String(content)
     }
 
-    const sampleResult: SampleResult = {
+    const sampleResult: RawSampleResultBase = {
       text: textContent,
       model,
       ...(stopReason !== undefined ? { stopReason } : {}),

--- a/packages/framework/src/lib/chat/mcp-tools/index.ts
+++ b/packages/framework/src/lib/chat/mcp-tools/index.ts
@@ -117,6 +117,10 @@ export {
   McpToolTimeoutError,
   McpDisconnectError,
   SampleValidationError,
+  // Sample exchange helpers
+  SCHEMA_TOOL_NAME,
+  createRawSampleExchange,
+  createStructuredSampleExchange,
 } from './mcp-tool-types.ts'
 
 // =============================================================================

--- a/packages/framework/src/lib/chat/mcp-tools/mcp-tool-types.ts
+++ b/packages/framework/src/lib/chat/mcp-tools/mcp-tool-types.ts
@@ -48,6 +48,18 @@ import type {
   ExtractElicitResponseSchema,
   ExtractElicitContextSchema,
 } from '@sweatpants/elicit-context'
+import type {
+  McpMessage,
+} from './protocol/types.js'
+
+// Re-export MCP types for convenience
+export type {
+  McpMessage,
+  McpContentBlock,
+  McpTextContent,
+  McpToolUseContent,
+  McpToolResultContent,
+} from './protocol/types.js'
 
 // =============================================================================
 // ELICITATION TYPES (shared)
@@ -56,14 +68,17 @@ import type {
 /**
  * Elicitation exchange - captures an elicitation as a request/response message pair.
  *
+ * Uses MCP content block format:
+ * - Request: assistant message with tool_use content block
+ * - Response: user message with tool_result content block
+ *
  * This enables tools to accumulate elicitation exchanges as conversation history
  * for sampling. The exchange captures:
  * - The context passed to elicit() (fully typed)
- * - The request as an assistant message with tool_call
- * - The response as a tool result message
+ * - The request as an assistant message with tool_use
+ * - The response as a user message with tool_result
  *
  * @template TContext - The type of context passed to elicit()
- * @template TResponse - The type of the user's response
  *
  * @example
  * ```typescript
@@ -88,30 +103,30 @@ export interface ElicitExchange<TContext> {
   context: TContext
 
   /**
-   * The elicitation request as an assistant message with tool_call.
-   * The tool_call arguments are empty by default for safety.
+   * The elicitation request as an assistant message with tool_use content.
+   * The tool_use input is empty by default for safety.
    */
-  request: AssistantToolCallMessage
+  request: McpMessage & { role: 'assistant' }
 
   /**
-   * The user's response as a tool result message.
+   * The user's response as a user message with tool_result content.
    * Content is the JSON-serialized response.
    */
-  response: ToolResultMessage
+  response: McpMessage & { role: 'user' }
 
   /**
    * Messages tuple [request, response] with empty arguments (safe default).
    * Ready to spread into a conversation history.
    */
-  messages: [AssistantToolCallMessage, ToolResultMessage]
+  messages: [McpMessage, McpMessage]
 
   /**
    * Build messages with custom arguments derived from captured context.
    *
    * The callback receives the fully typed context and returns the arguments
-   * to include in the tool_call. This is opt-in context exposure.
+   * to include in the tool_use input. This is opt-in context exposure.
    *
-   * @param fn - Function that derives tool call arguments from context
+   * @param fn - Function that derives tool_use input from context
    * @returns Messages tuple with populated arguments
    *
    * @example
@@ -124,7 +139,7 @@ export interface ElicitExchange<TContext> {
    */
   withArguments(
     fn: (context: TContext) => Record<string, unknown>
-  ): [AssistantToolCallMessage, ToolResultMessage]
+  ): [McpMessage, McpMessage]
 }
 
 /**
@@ -176,6 +191,75 @@ export interface ElicitConfig<T> {
    * Nested objects and arrays are NOT supported.
    */
   schema: z.ZodType<T>
+}
+
+// =============================================================================
+// SAMPLE EXCHANGE TYPE
+// =============================================================================
+
+/**
+ * Sampling exchange - captures a sampling interaction as accumulate-able messages.
+ *
+ * An exchange represents the interaction for context history purposes.
+ * It's not a pedantic record of what went over the wire - it models the
+ * data flow correctly so the context window makes sense.
+ *
+ * Uses MCP content block format:
+ * - Raw sampling: 2 messages [user, assistant]
+ * - Structured output: 3 messages [user, assistant (tool_use), user (tool_result)]
+ *
+ * For structured output, the "response" is split into 2 messages to be MCP-compliant
+ * (tool_use MUST be followed by tool_result).
+ *
+ * @template TParsed - The type of parsed structured output (undefined for raw sampling)
+ *
+ * @example Raw sampling
+ * ```typescript
+ * const result = yield* ctx.sample({ prompt: 'Analyze this' })
+ * history.push(...result.exchange.messages) // 2 messages
+ * ```
+ *
+ * @example Structured output
+ * ```typescript
+ * const result = yield* ctx.sample({
+ *   prompt: 'Pick a move',
+ *   schema: z.object({ cell: z.number() })
+ * })
+ * if (result.parsed) {
+ *   history.push(...result.exchange.messages) // 3 messages
+ *   console.log('Move:', result.exchange.parsed.cell)
+ * }
+ * ```
+ */
+export interface SampleExchange<TParsed = undefined> {
+  /**
+   * The request message we sent to the model.
+   * Always a user message with text content.
+   */
+  request: McpMessage & { role: 'user' }
+
+  /**
+   * The assistant's response message.
+   * - Raw sampling: text content
+   * - Structured output: tool_use content (calling __schema__)
+   */
+  response: McpMessage & { role: 'assistant' }
+
+  /**
+   * All messages for history accumulation.
+   * - Raw sampling: [request, response] = 2 messages
+   * - Structured output: [request, toolUse, toolResult] = 3 messages
+   *
+   * For structured output, we construct the toolResult as an acknowledgment
+   * to close the interaction properly for MCP compliance.
+   */
+  messages: McpMessage[]
+
+  /**
+   * Parsed structured data (only present when schema was used).
+   * Extracted from the tool_use input and validated against the schema.
+   */
+  parsed: TParsed
 }
 
 // =============================================================================
@@ -306,75 +390,42 @@ export interface Message {
 }
 
 // =============================================================================
-// EXTENDED MESSAGE TYPES (MCP++)
+// EXTENDED MESSAGE TYPES (MCP)
 // =============================================================================
-// The official MCP spec for sampling/createMessage only supports
-// TextContent | ImageContent | AudioContent. We extend this with
-// tool calling support for richer sampling patterns.
 
 /**
- * A tool call made by the assistant.
+ * Extended message type supporting both basic messages and MCP content blocks.
  * 
- * Used in MCP++ sampling to represent tool calls in conversation history.
+ * This type supports:
+ * - Basic text messages (user/assistant/system with string content)
+ * - MCP messages with content blocks (tool_use, tool_result, etc.)
+ *
+ * Use MCP content block format for tool interactions:
+ * - Assistant tool calls: role 'assistant' with tool_use content blocks
+ * - Tool results: role 'user' with tool_result content blocks
+ *
+ * @example Basic text message
+ * ```typescript
+ * const msg: ExtendedMessage = { role: 'user', content: 'Hello' }
+ * ```
+ *
+ * @example MCP tool use
+ * ```typescript
+ * const msg: ExtendedMessage = {
+ *   role: 'assistant',
+ *   content: [{ type: 'tool_use', id: 'call_1', name: 'get_weather', input: { city: 'NYC' } }]
+ * }
+ * ```
+ *
+ * @example MCP tool result
+ * ```typescript
+ * const msg: ExtendedMessage = {
+ *   role: 'user',
+ *   content: [{ type: 'tool_result', toolUseId: 'call_1', content: [{ type: 'text', text: '72F' }] }]
+ * }
+ * ```
  */
-export interface ToolCall {
-  /** Unique ID for this tool call (for correlation with results) */
-  id: string
-  
-  /** Always 'function' for now */
-  type: 'function'
-  
-  /** The function being called */
-  function: {
-    /** Function/tool name */
-    name: string
-    
-    /** Arguments to the function */
-    arguments: Record<string, unknown>
-  }
-}
-
-/**
- * Assistant message with tool calls.
- * 
- * Represents an assistant turn that includes one or more tool calls.
- * Used in MCP++ sampling to build conversation history with tool interactions.
- */
-export interface AssistantToolCallMessage {
-  role: 'assistant'
-  
-  /** Optional text content alongside tool calls */
-  content: string | null
-  
-  /** Tool calls made by the assistant */
-  tool_calls: ToolCall[]
-}
-
-/**
- * Tool result message.
- * 
- * Represents the result of a tool call.
- * Used in MCP++ sampling to include tool results in conversation history.
- */
-export interface ToolResultMessage {
-  role: 'tool'
-  
-  /** ID of the tool call this result is for */
-  tool_call_id: string
-  
-  /** The tool result (serialized as string) */
-  content: string
-}
-
-/**
- * Extended message type supporting both basic messages and tool interactions.
- * 
- * This is the MCP++ message type that supports:
- * - Basic text messages (user/assistant/system)
- * - Assistant messages with tool calls
- * - Tool result messages
- */
-export type ExtendedMessage = Message | AssistantToolCallMessage | ToolResultMessage
+export type ExtendedMessage = Message | McpMessage
 
 // =============================================================================
 // SAMPLING TYPES

--- a/packages/framework/src/lib/chat/mcp-tools/mock-runtime.ts
+++ b/packages/framework/src/lib/chat/mcp-tools/mock-runtime.ts
@@ -184,6 +184,7 @@ export function createMockMCPClient(config: MockMCPClientConfig = {}): MockMCPCl
                 type: 'tool_use',
                 id: toolCallId,
                 name: 'elicit',
+                // Keep input empty; echo data in tool_result for history
                 input: {},
               }],
             }

--- a/packages/framework/src/lib/chat/mcp-tools/mock-runtime.ts
+++ b/packages/framework/src/lib/chat/mcp-tools/mock-runtime.ts
@@ -33,8 +33,7 @@ import type {
   SampleConfig,
   LogLevel,
   ElicitExchange,
-  AssistantToolCallMessage,
-  ToolResultMessage,
+  McpMessage,
 } from './types.ts'
 import {
   MCPCapabilityError,
@@ -177,24 +176,24 @@ export function createMockMCPClient(config: MockMCPClientConfig = {}): MockMCPCl
               return response as ElicitResult<unknown, T>
             }
 
-            // Construct a mock exchange for accept responses
+            // Construct a mock exchange for accept responses using MCP format
             const toolCallId = `mock_elicit_${Date.now()}`
-            const request: AssistantToolCallMessage = {
+            const request: McpMessage & { role: 'assistant' } = {
               role: 'assistant',
-              content: null,
-              tool_calls: [{
+              content: [{
+                type: 'tool_use',
                 id: toolCallId,
-                type: 'function',
-                function: {
-                  name: 'elicit',
-                  arguments: {},
-                },
+                name: 'elicit',
+                input: {},
               }],
             }
-            const toolResponse: ToolResultMessage = {
-              role: 'tool',
-              tool_call_id: toolCallId,
-              content: JSON.stringify(response.content),
+            const toolResponse: McpMessage & { role: 'user' } = {
+              role: 'user',
+              content: [{
+                type: 'tool_result',
+                toolUseId: toolCallId,
+                content: [{ type: 'text', text: JSON.stringify(response.content) }],
+              }],
             }
             
             const exchange: ElicitExchange<unknown> = {

--- a/packages/framework/src/lib/chat/mcp-tools/session/tool-session.ts
+++ b/packages/framework/src/lib/chat/mcp-tools/session/tool-session.ts
@@ -41,7 +41,7 @@ import type {
 } from './types.ts'
 import type {
   RawElicitResult,
-  SampleResult,
+  RawSampleResult,
   ElicitsMap,
 } from '../mcp-tool-types.ts'
 import type { FinalizedMcpToolWithElicits } from '../mcp-tool-builder.ts'
@@ -291,7 +291,7 @@ export function createToolSession<
         yield* sleep(0)
       },
 
-      *respondToSample(sampleId: string, response: SampleResult): Operation<void> {
+      *respondToSample(sampleId: string, response: RawSampleResult): Operation<void> {
         const pending = state.pendingSample
         if (!pending) {
           return

--- a/packages/framework/src/lib/chat/mcp-tools/session/types.ts
+++ b/packages/framework/src/lib/chat/mcp-tools/session/types.ts
@@ -28,9 +28,9 @@
 import type { Operation, Stream } from 'effection'
 import type {
   RawElicitResult,
-  SampleResultBase,
-  SampleResultWithParsed,
-  SampleResultWithToolCalls,
+  RawSampleResultBase,
+  RawSampleResultWithParsed,
+  RawSampleResultWithToolCalls,
   SamplingToolDefinition,
   SamplingToolChoice,
   Message,
@@ -45,6 +45,10 @@ export type {
   SampleResultBase,
   SampleResultWithParsed,
   SampleResultWithToolCalls,
+  RawSampleResultBase,
+  RawSampleResultWithParsed,
+  RawSampleResultWithToolCalls,
+  RawSampleResult,
 } from '../mcp-tool-types.ts'
 
 // =============================================================================
@@ -230,9 +234,9 @@ export interface ToolSession<TResult = unknown> {
    * Respond to a sampling request.
    *
    * @param sampleId - The ID from the SampleRequestEvent
-   * @param response - The LLM's response (may include parsed data or tool calls)
+   * @param response - The LLM's response (raw result without exchange - exchange is constructed by runtime)
    */
-  respondToSample(sampleId: string, response: SampleResultBase | SampleResultWithParsed<unknown> | SampleResultWithToolCalls): Operation<void>
+  respondToSample(sampleId: string, response: RawSampleResultBase | RawSampleResultWithParsed<unknown> | RawSampleResultWithToolCalls): Operation<void>
 
   /**
    * Emit an internal event to wake up the SSE stream.
@@ -404,12 +408,12 @@ export interface ToolSessionSamplingProvider {
    * 
    * @param messages - Messages to send to the LLM
    * @param options - Sampling options including tools and schema
-   * @returns The LLM response, potentially with parsed data or tool calls
+   * @returns The LLM response (raw result without exchange)
    */
   sample(
     messages: Message[],
     options?: ToolSessionSamplingOptions
-  ): Operation<SampleResultBase | SampleResultWithParsed<unknown> | SampleResultWithToolCalls>
+  ): Operation<RawSampleResultBase | RawSampleResultWithParsed<unknown> | RawSampleResultWithToolCalls>
 }
 
 /**

--- a/packages/framework/src/lib/chat/mcp-tools/session/worker-tool-session.ts
+++ b/packages/framework/src/lib/chat/mcp-tools/session/worker-tool-session.ts
@@ -34,7 +34,7 @@ import type {
   ToolSession,
   ToolSessionStatus,
   ToolSessionEvent,
-  SampleResult,
+  RawSampleResult,
 } from './types.ts'
 import type {
   HostTransport,
@@ -216,7 +216,7 @@ export function createWorkerToolSession(
         status = 'running'
       },
 
-      *respondToSample(sampleId: string, response: SampleResult): Operation<void> {
+      *respondToSample(sampleId: string, response: RawSampleResult): Operation<void> {
         if (!pendingSamples.has(sampleId)) {
           throw new Error(`No pending sample request with ID: ${sampleId}`)
         }

--- a/packages/framework/src/lib/chat/mcp-tools/session/worker-types.ts
+++ b/packages/framework/src/lib/chat/mcp-tools/session/worker-types.ts
@@ -37,7 +37,7 @@ import type { Operation } from 'effection'
 import type {
   Message,
   LogLevel,
-  SampleResult,
+  RawSampleResult,
   ElicitResult,
   RawElicitResult,
   SamplingToolDefinition,
@@ -73,8 +73,8 @@ export interface SampleResponseMessage {
   type: 'sample_response'
   /** Correlates with SampleRequestMessage.sampleId */
   sampleId: string
-  /** The LLM's response */
-  response: SampleResult
+  /** The LLM's response (raw result without exchange) */
+  response: RawSampleResult
 }
 
 /**
@@ -347,13 +347,13 @@ export interface WorkerToolContext {
   progress(message: string, progress?: number): void
 
   /**
-   * Request LLM sampling.
+   * Request an LLM completion.
    * Suspends until response is received via transport.
    */
   sample(
     messages: Message[],
     options?: { systemPrompt?: string; maxTokens?: number }
-  ): Operation<SampleResult>
+  ): Operation<RawSampleResult>
 
   /**
    * Request user input.

--- a/packages/framework/src/lib/chat/mcp-tools/types.ts
+++ b/packages/framework/src/lib/chat/mcp-tools/types.ts
@@ -43,20 +43,26 @@ import type {
   ElicitExchange as _ElicitExchange,
   ElicitResult as _ElicitResult,
   RawElicitResult as _RawElicitResult,
-  AssistantToolCallMessage as _AssistantToolCallMessage,
-  ToolResultMessage as _ToolResultMessage,
-  ToolCall as _ToolCall,
   ExtendedMessage as _ExtendedMessage,
+  SampleExchange as _SampleExchange,
+  McpMessage as _McpMessage,
+  McpContentBlock as _McpContentBlock,
+  McpToolUseContent as _McpToolUseContent,
+  McpToolResultContent as _McpToolResultContent,
 } from './mcp-tool-types.ts'
 
 // Re-export for consumers
 export type ElicitExchange<T> = _ElicitExchange<T>
 export type ElicitResult<TContext, TResponse> = _ElicitResult<TContext, TResponse>
 export type RawElicitResult<TResponse> = _RawElicitResult<TResponse>
-export type AssistantToolCallMessage = _AssistantToolCallMessage
-export type ToolResultMessage = _ToolResultMessage
-export type ToolCall = _ToolCall
 export type ExtendedMessage = _ExtendedMessage
+export type SampleExchange<T = undefined> = _SampleExchange<T>
+
+// MCP content block types
+export type McpMessage = _McpMessage
+export type McpContentBlock = _McpContentBlock
+export type McpToolUseContent = _McpToolUseContent
+export type McpToolResultContent = _McpToolResultContent
 
 /**
  * Configuration for an elicitation request.

--- a/packages/framework/src/lib/chat/mcp-tools/types.ts
+++ b/packages/framework/src/lib/chat/mcp-tools/types.ts
@@ -49,6 +49,17 @@ import type {
   McpContentBlock as _McpContentBlock,
   McpToolUseContent as _McpToolUseContent,
   McpToolResultContent as _McpToolResultContent,
+  RawSampleResultBase as _RawSampleResultBase,
+  RawSampleResultWithParsed as _RawSampleResultWithParsed,
+  RawSampleResultWithToolCalls as _RawSampleResultWithToolCalls,
+  RawSampleResult as _RawSampleResult,
+} from './mcp-tool-types.ts'
+
+// Re-export helper functions
+export {
+  SCHEMA_TOOL_NAME,
+  createRawSampleExchange,
+  createStructuredSampleExchange,
 } from './mcp-tool-types.ts'
 
 // Re-export for consumers
@@ -63,6 +74,12 @@ export type McpMessage = _McpMessage
 export type McpContentBlock = _McpContentBlock
 export type McpToolUseContent = _McpToolUseContent
 export type McpToolResultContent = _McpToolResultContent
+
+// Raw sample result types (without exchange - for decoder/handler layers)
+export type RawSampleResultBase = _RawSampleResultBase
+export type RawSampleResultWithParsed<T> = _RawSampleResultWithParsed<T>
+export type RawSampleResultWithToolCalls = _RawSampleResultWithToolCalls
+export type RawSampleResult = _RawSampleResult
 
 /**
  * Configuration for an elicitation request.


### PR DESCRIPTION
# MCP Spec Alignment - Design Document

## Overview

This document describes the design for aligning sweatpants with the MCP 2025-11-25 specification, including breaking changes to message format, adding the `__schema__` meta-tool pattern for structured output, and introducing `SampleExchange` for history accumulation.

## Goals

1. **Message format alignment** - Switch from OpenAI-style to MCP content blocks
2. **URL elicitation guard** - Throw clear error if `mode: 'url'` is attempted
3. **`__schema__` meta-tool pattern** - Convert `ctx.sample({ schema })` to a reserved tool
4. **`SampleExchange` type** - Parallel to `ElicitExchange`, captures sampling as accumulate-able exchanges

