### PR TITLE
Really tight git diff of worker transport changes

### DIFF
--- a/packages/core/src/agent/create.ts
+++ b/packages/core/src/agent/create.ts
@@ -1,6 +1,6 @@
 import { createContext, scoped } from "effection";
 import type { Operation } from "effection";
-import type { ZodSchema, infer as ZodInfer, input as ZodInput } from "zod";
+import type { z, ZodSchema, input as ZodInput } from "zod";
 import type {
   AgentConfig,
   Agent,
@@ -74,7 +74,7 @@ export function createAgent<
 ): AgentFactory<TConfig, TTools> {
   // Create config context unique to this agent
   // This will be used by useConfig() to retrieve the config
-  const configContext = createContext<ZodInfer<NonNullable<TConfig>>>(
+  const configContext = createContext<z.infer<NonNullable<TConfig>>>(
     `agent.${agentConfig.name}.config`,
   );
 
@@ -86,7 +86,7 @@ export function createAgent<
     return scoped(function* () {
       // Validate and set config if schema exists
       if (agentConfig.config) {
-        const validated = agentConfig.config.parse(inputConfig) as ZodInfer<
+        const validated = agentConfig.config.parse(inputConfig) as z.infer<
           NonNullable<TConfig>
         >;
         yield* configContext.set(validated);
@@ -111,7 +111,7 @@ export function createAgent<
    * Must be called within the agent's scope (i.e., after activation).
    * Throws if called outside agent scope or if agent has no config schema.
    */
-  function useConfig(): Operation<ZodInfer<NonNullable<TConfig>>> {
+  function useConfig(): Operation<z.infer<NonNullable<TConfig>>> {
     return {
       *[Symbol.iterator]() {
         if (!agentConfig.config) {

--- a/packages/core/src/agent/types.ts
+++ b/packages/core/src/agent/types.ts
@@ -1,5 +1,5 @@
 import type { Operation } from "effection";
-import type { ZodSchema, infer as ZodInfer, input as ZodInput } from "zod";
+import type { z, ZodSchema, input as ZodInput } from "zod";
 import type {
   Tool,
   ToolMiddleware,
@@ -124,7 +124,7 @@ export interface AgentFactoryWithConfig<
   /** Activate the agent with configuration (uses z.input to allow defaults) */
   (config: ZodInput<TConfig>): Operation<Agent<TTools>>;
   /** Access agent config from within a tool (must be in agent's scope) */
-  useConfig(): Operation<ZodInfer<TConfig>>;
+  useConfig(): Operation<z.infer<TConfig>>;
 }
 
 /**

--- a/packages/core/src/builtins/types.ts
+++ b/packages/core/src/builtins/types.ts
@@ -1,4 +1,4 @@
-import type { ZodSchema, infer as ZodInfer } from "zod";
+import type { z, ZodSchema } from "zod";
 
 // ============================================================================
 // Elicit Types
@@ -22,7 +22,7 @@ export interface ElicitOptions<TSchema extends ZodSchema> {
  * Result of an elicit operation.
  */
 export type ElicitResult<TSchema extends ZodSchema> =
-  | { status: "accepted"; value: ZodInfer<TSchema> }
+  | { status: "accepted"; value: z.infer<TSchema> }
   | { status: "declined" }
   | { status: "cancelled" };
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -89,49 +89,14 @@ export {
   type Inspector,
 } from "./protocol/index.ts";
 
-// Re-export worker transport utilities and types
-export {
-  // Host-side
-  createWorkerPrincipal,
-  generateRequestId,
-  createSampleResponse,
-  createElicitResponse,
-  type WorkerPrincipalOptions,
-  type WorkerPrincipalResult,
-  type WorkerRequestHandler,
-  type ForEachContext,
-  // Worker-side
-  runToolWorker,
-  runRequestHandler,
-  type ToolWorkerHandler,
-  // Types
-  type WorkerRequest,
-  type WorkerSampleRequest,
-  type WorkerElicitRequest,
-  type WorkerResponse,
-  type WorkerSampleResponse,
-  type WorkerElicitResponse,
-  type WorkerProgressMessage,
-  type WorkerLogMessage,
-  type WorkerOutOfBandMessage,
-  type WorkerInitData,
-  type WorkerResult,
-  type WorkerSuccessResult,
-  type WorkerErrorResult,
-  type WorkerCancelledResult,
-  type WorkerMessage,
-  type WorkerMessageRole,
-  type WorkerContentBlock,
-  type WorkerTextContent,
-  type WorkerToolUseContent,
-  type WorkerToolResultContent,
-  type WorkerModelPreferences,
-  type WorkerToolDefinition,
-  type WorkerToolChoice,
-  type WorkerToolCall,
-  type WorkerToolContext,
-  // Type guards
-  isProgressMessage,
-  isLogMessage,
-  isOutOfBandMessage,
-} from "./transport/worker/index.ts";
+// =============================================================================
+// WORKER TRANSPORT
+// =============================================================================
+//
+// Worker transport is NOT exported from the main entry to avoid pulling
+// @effectionx/worker (which uses Node.js worker_threads) into browser bundles.
+//
+// For worker transport functionality, import from:
+//   @sweatpants/core/transport/worker
+//
+// =============================================================================

--- a/packages/core/src/protocol/types.ts
+++ b/packages/core/src/protocol/types.ts
@@ -1,5 +1,5 @@
 import type { Operation, Stream } from "effection";
-import type { ZodSchema, infer as ZodInfer } from "zod";
+import type { z, ZodSchema } from "zod";
 
 // ============================================================================
 // Method Definition
@@ -51,7 +51,7 @@ export interface InvocationArgs<M extends Methods, N extends keyof M = keyof M> 
   /** The method name to invoke */
   name: N;
   /** The arguments to pass to the method */
-  args: ZodInfer<M[N]["input"]>;
+  args: z.infer<M[N]["input"]>;
 }
 
 /**
@@ -59,8 +59,8 @@ export interface InvocationArgs<M extends Methods, N extends keyof M = keyof M> 
  * that closes with the final result.
  */
 export type InvocationResult<M extends Methods, N extends keyof M = keyof M> = Stream<
-  ZodInfer<M[N]["progress"]>,
-  ZodInfer<M[N]["output"]>
+  z.infer<M[N]["progress"]>,
+  z.infer<M[N]["output"]>
 >;
 
 // ============================================================================
@@ -72,15 +72,15 @@ export type InvocationResult<M extends Methods, N extends keyof M = keyof M> = S
  * Takes input args and returns a stream of progress/result.
  */
 export type MethodHandler<M extends Methods, N extends keyof M> = 
-  (args: ZodInfer<M[N]["input"]>) => Stream<ZodInfer<M[N]["progress"]>, ZodInfer<M[N]["output"]>>;
+  (args: z.infer<M[N]["input"]>) => Stream<z.infer<M[N]["progress"]>, z.infer<M[N]["output"]>>;
 
 /**
  * A record of method handlers matching a protocol's methods.
  */
 export type MethodHandlers<M extends Methods> = {
-  [N in keyof M]: (args: ZodInfer<M[N]["input"]>) => Stream<
-    ZodInfer<M[N]["progress"]>,
-    ZodInfer<M[N]["output"]>
+  [N in keyof M]: (args: z.infer<M[N]["input"]>) => Stream<
+    z.infer<M[N]["progress"]>,
+    z.infer<M[N]["output"]>
   >;
 };
 

--- a/packages/core/src/tool/create.ts
+++ b/packages/core/src/tool/create.ts
@@ -1,6 +1,6 @@
 import { createApi } from "effection/experimental";
 import type { Context, Operation, Subscription } from "effection";
-import type { ZodSchema, infer as ZodInfer } from "zod";
+import type { z, ZodSchema } from "zod";
 import type {
   ToolConfig,
   ToolImplFn,
@@ -78,8 +78,8 @@ export function createTool<
 >(
   config: ToolConfig<TInput, TProgress, TOutput>,
 ): ToolFactoryWithImpl<TInput, TOutput> | ToolFactoryWithoutImpl<TInput, TProgress, TOutput> {
-  type Input = ZodInfer<TInput>;
-  type Output = ZodInfer<TOutput>;
+  type Input = z.infer<TInput>;
+  type Output = z.infer<TOutput>;
 
   // Create the API for this tool
   // The handler is the default impl or a placeholder that routes to transport
@@ -127,7 +127,7 @@ export function createTool<
               const requestId = `${config.name}-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
               
               // Send request through transport and get response stream
-              const stream = transport.request<ZodInfer<TProgress>, ElicitResponse>({
+              const stream = transport.request<z.infer<TProgress>, ElicitResponse>({
                 id: requestId,
                 kind: "elicit",
                 type: config.name,
@@ -135,7 +135,7 @@ export function createTool<
               });
               
               // Subscribe to the stream
-              const subscription: Subscription<ZodInfer<TProgress>, ElicitResponse> = yield* stream;
+              const subscription: Subscription<z.infer<TProgress>, ElicitResponse> = yield* stream;
               
               // Consume the stream until we get the final response
               // Progress updates are currently ignored (TODO: expose via callback or context)
@@ -230,11 +230,11 @@ function createToolWithBindings<
   TOutput extends ZodSchema,
 >(
   config: ToolConfig<TInput, TProgress, TOutput>,
-  api: ReturnType<typeof createApi<{ invoke: (args: ZodInfer<TInput>) => Operation<ZodInfer<TOutput>> }>>,
+  api: ReturnType<typeof createApi<{ invoke: (args: z.infer<TInput>) => Operation<z.infer<TOutput>> }>>,
   bindings: ContextBinding[],
 ): ToolFactoryWithImpl<TInput, TOutput> | ToolFactoryWithoutImpl<TInput, TProgress, TOutput> {
-  type Input = ZodInfer<TInput>;
-  type Output = ZodInfer<TOutput>;
+  type Input = z.infer<TInput>;
+  type Output = z.infer<TOutput>;
 
   // Factory function that activates the tool with context bindings
   function factory(
@@ -270,7 +270,7 @@ function createToolWithBindings<
               const requestId = `${config.name}-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
               
               // Send request through transport and get response stream
-              const stream = transport.request<ZodInfer<TProgress>, ElicitResponse>({
+              const stream = transport.request<z.infer<TProgress>, ElicitResponse>({
                 id: requestId,
                 kind: "elicit",
                 type: config.name,
@@ -278,7 +278,7 @@ function createToolWithBindings<
               });
               
               // Subscribe to the stream
-              const subscription: Subscription<ZodInfer<TProgress>, ElicitResponse> = yield* stream;
+              const subscription: Subscription<z.infer<TProgress>, ElicitResponse> = yield* stream;
               
               // Consume the stream until we get the final response
               let result = yield* subscription.next();

--- a/packages/core/src/tool/types.ts
+++ b/packages/core/src/tool/types.ts
@@ -1,5 +1,5 @@
 import type { Context, Operation } from "effection";
-import type { ZodSchema, infer as ZodInfer } from "zod";
+import type { z, ZodSchema } from "zod";
 
 /**
  * A binding of a context to a value, used for Tool.withContext().
@@ -40,18 +40,18 @@ export type ToolImplFn<
   TProgress extends ZodSchema | undefined,
   TOutput extends ZodSchema,
 > = (
-  args: ZodInfer<TInput>,
+  args: z.infer<TInput>,
   send: TProgress extends ZodSchema
-    ? (progress: ZodInfer<TProgress>) => Operation<void>
+    ? (progress: z.infer<TProgress>) => Operation<void>
     : never,
-) => Operation<ZodInfer<TOutput>>;
+) => Operation<z.infer<TOutput>>;
 
 /**
  * An activated tool that can be invoked with input.
  */
 export type Tool<TInput extends ZodSchema, TOutput extends ZodSchema> = (
-  args: ZodInfer<TInput>,
-) => Operation<ZodInfer<TOutput>>;
+  args: z.infer<TInput>,
+) => Operation<z.infer<TOutput>>;
 
 /**
  * Middleware function for decorating tool invocations.
@@ -60,9 +60,9 @@ export type ToolMiddleware<
   TInput extends ZodSchema,
   TOutput extends ZodSchema,
 > = (
-  args: ZodInfer<TInput>,
-  next: (...args: [ZodInfer<TInput>]) => Operation<ZodInfer<TOutput>>,
-) => Operation<ZodInfer<TOutput>>;
+  args: z.infer<TInput>,
+  next: (...args: [z.infer<TInput>]) => Operation<z.infer<TOutput>>,
+) => Operation<z.infer<TOutput>>;
 
 /**
  * Tool factory returned when impl is provided in config.

--- a/packages/core/src/transport/worker/host.ts
+++ b/packages/core/src/transport/worker/host.ts
@@ -88,6 +88,13 @@ export interface WorkerPrincipalOptions {
   initData: WorkerInitData;
 
   /**
+   * Additional exec arguments for the worker thread.
+   * Use this to pass flags like '--import tsx' or '--experimental-strip-types'
+   * to enable TypeScript support in worker threads during development.
+   */
+  execArgv?: string[];
+
+  /**
    * Handler for processing requests from the worker.
    * This is called for each sample/elicit request.
    */
@@ -124,9 +131,11 @@ export interface WorkerPrincipalResult<T = unknown> {
 export function* createWorkerPrincipal<T = unknown>(
   options: WorkerPrincipalOptions
 ): Operation<WorkerPrincipalResult<T>> {
-  const { workerUrl, initData, requestHandler } = options;
+  const { workerUrl, initData, requestHandler, execArgv } = options;
 
   return yield* resource<WorkerPrincipalResult<T>>(function* (provide) {
+    let outcome: WorkerResult<T> | null = null;
+    let resultSettled = false;
     // Create the worker using @effectionx/worker
     // Type parameters:
     // TSend = never (host doesn't send requests via worker.send() in our model)
@@ -139,29 +148,72 @@ export function* createWorkerPrincipal<T = unknown>(
         {
           type: "module",
           data: initData,
-        }
+          // Pass execArgv to enable TypeScript loaders in worker threads.
+          // This flows through: useWorker -> web-worker -> node:worker_threads
+          ...(execArgv && execArgv.length > 0 ? { execArgv } : {}),
+        } as any
       );
 
     // Spawn the forEach handler to process worker requests
     // This runs in the background and handles all requests from the worker
     yield* spawn(function* () {
-      // Use worker.forEach with the progress-enabled signature
-      // WRequest = WorkerRequest (what worker sends)
-      // WResponse = WorkerResponse (what we send back)
-      // WProgress = WorkerProgressMessage (progress updates)
-      yield* worker.forEach<WorkerRequest, WorkerResponse, WorkerProgressMessage>(
-        function* (request, ctx) {
-          // Call the user-provided request handler
-          return yield* requestHandler(request, ctx);
+      try {
+        // Use worker.forEach with the progress-enabled signature
+        // WRequest = WorkerRequest (what worker sends)
+        // WResponse = WorkerResponse (what we send back)
+        // WProgress = WorkerProgressMessage (progress updates)
+        yield* worker.forEach<WorkerRequest, WorkerResponse, WorkerProgressMessage>(
+          function* (request, ctx) {
+            // Call the user-provided request handler
+            return yield* requestHandler(request, ctx);
+          }
+        );
+      } catch (error) {
+        if (!resultSettled) {
+          const err = error as Error;
+          outcome = {
+            type: "error",
+            error: {
+              name: err.name,
+              message: err.message,
+              stack: err.stack,
+            },
+          };
+          resultSettled = true;
         }
-      );
+      }
     });
 
     // Create result operation wrapper
     const resultOperation: Operation<WorkerResult<T>> = {
       *[Symbol.iterator]() {
-        // Yield the worker's final result
-        return yield* worker;
+        if (resultSettled && outcome) {
+          return outcome;
+        }
+
+        try {
+          // Yield the worker's final result
+          const result = yield* worker;
+          if (!resultSettled) {
+            outcome = result;
+            resultSettled = true;
+          }
+          return result;
+        } catch (error) {
+          if (!resultSettled) {
+            const err = error as Error;
+            outcome = {
+              type: "error",
+              error: {
+                name: err.name,
+                message: err.message,
+                stack: err.stack,
+              },
+            };
+            resultSettled = true;
+          }
+          return outcome as WorkerResult<T>;
+        }
       },
     };
 

--- a/packages/core/src/transport/worker/runner.ts
+++ b/packages/core/src/transport/worker/runner.ts
@@ -135,7 +135,7 @@ export async function runToolWorker<T = unknown>(
 
         *elicit<TContent>(
           key: string,
-          options: { message: string; schema: Record<string, unknown> }
+          options: { message: string; schema: Record<string, unknown>; context?: Record<string, unknown> }
         ): Operation<WorkerElicitResponse & { content?: TContent }> {
           const id = generateRequestId();
           const request: WorkerElicitRequest = {
@@ -144,6 +144,7 @@ export async function runToolWorker<T = unknown>(
             key,
             message: options.message,
             schema: options.schema,
+            ...(options.context !== undefined && { context: options.context }),
           };
 
           return yield* sendRequestToHost<WorkerElicitRequest, WorkerElicitResponse>(request) as Operation<

--- a/packages/core/src/transport/worker/types.ts
+++ b/packages/core/src/transport/worker/types.ts
@@ -77,6 +77,8 @@ export interface WorkerElicitRequest extends WorkerRequestBase {
   message: string;
   /** JSON Schema for expected response */
   schema: Record<string, unknown>;
+  /** Context data for the UI to render (e.g., flight options, seat map) */
+  context?: Record<string, unknown>;
 }
 
 /**
@@ -339,7 +341,7 @@ export interface WorkerToolContext {
    */
   elicit<T = unknown>(
     key: string,
-    options: { message: string; schema: Record<string, unknown> }
+    options: { message: string; schema: Record<string, unknown>; context?: Record<string, unknown> }
   ): Operation<WorkerElicitResponse & { content?: T }>;
 
   /**

--- a/packages/framework/src/lib/chat/mcp-tools/session/session-registry.ts
+++ b/packages/framework/src/lib/chat/mcp-tools/session/session-registry.ts
@@ -27,6 +27,26 @@ import type {
 import type { ElicitsMap } from '../mcp-tool-types.ts'
 import type { FinalizedMcpToolWithElicits } from '../mcp-tool-builder.ts'
 import { createToolSession } from './tool-session.ts'
+import { createWorkerToolSession } from './worker-tool-session.ts'
+
+function resolveWorkerUrl(workerUrl: string | URL, isDev?: boolean): string | URL {
+  if (!isDev) return workerUrl
+
+  if (workerUrl instanceof URL) {
+    if (workerUrl.protocol === 'file:') return workerUrl
+    const cacheBusted = new URL(workerUrl.toString())
+    cacheBusted.searchParams.set('t', Date.now().toString())
+    return cacheBusted
+  }
+
+  if (/^https?:\/\//.test(workerUrl)) {
+    const cacheBusted = new URL(workerUrl)
+    cacheBusted.searchParams.set('t', Date.now().toString())
+    return cacheBusted
+  }
+
+  return workerUrl
+}
 
 // =============================================================================
 // SESSION REGISTRY IMPLEMENTATION
@@ -46,6 +66,17 @@ export interface ToolSessionRegistryOptions {
    * @default undefined (no timeout)
    */
   defaultTimeout?: number
+
+  /**
+   * Worker mode configuration (optional).
+   * When set, tool sessions run in worker threads via createWorkerToolSession.
+   */
+  worker?: {
+    workerUrl: string | URL
+    isDev?: boolean
+    /** Extra execArgv for worker threads (e.g., ['--import', 'tsx'] for TypeScript support in dev) */
+    execArgv?: string[]
+  }
 }
 
 /**
@@ -68,7 +99,7 @@ export function createToolSessionRegistry(
   options: ToolSessionRegistryOptions
 ): Operation<ToolSessionRegistry> {
   return resource<ToolSessionRegistry>(function* (provide) {
-    const { samplingProvider, defaultTimeout } = options
+    const { samplingProvider, defaultTimeout, worker } = options
 
     // Track active session resources
     const activeSessions = new Map<string, ToolSession>()
@@ -102,15 +133,28 @@ export function createToolSessionRegistry(
         // that request scope, it would be cancelled and could not be resumed on
         // the next HTTP request.
         yield* useBackgroundTask(function* () {
-          const session = yield* createToolSession(
-            tool,
-            params,
-            samplingProvider,
-            mergedOptions
-          )
+          const resolvedWorkerUrl = worker
+            ? resolveWorkerUrl(worker.workerUrl, worker.isDev)
+            : undefined
+          const session = (worker
+            ? yield* createWorkerToolSession({
+                sessionId: mergedOptions.sessionId ?? tool.name,
+                toolName: tool.name,
+                params,
+                workerUrl: resolvedWorkerUrl ?? worker.workerUrl,
+                ...(mergedOptions.systemPrompt !== undefined && { systemPrompt: mergedOptions.systemPrompt }),
+                ...(mergedOptions.parentMessages !== undefined && { parentMessages: mergedOptions.parentMessages }),
+                ...(worker.execArgv && worker.execArgv.length > 0 ? { execArgv: worker.execArgv } : {}),
+              })
+            : yield* createToolSession(
+                tool,
+                params,
+                samplingProvider,
+                mergedOptions
+              )) as ToolSession<TResult>
 
-          // Send session back to caller
-          yield* sessionChannel.send(session)
+        // Send session back to caller
+        yield* sessionChannel.send(session)
 
           // Keep this task alive until the session completes
           // This ensures the session's spawned tasks continue running

--- a/packages/framework/src/lib/chat/mcp-tools/session/worker-runner.ts
+++ b/packages/framework/src/lib/chat/mcp-tools/session/worker-runner.ts
@@ -29,8 +29,9 @@ import {
   type WorkerMessage,
   type WorkerSampleResponse,
   type WorkerElicitResponse,
-} from '@sweatpants/core'
+} from '@sweatpants/core/transport/worker'
 import type { Operation } from 'effection'
+import { zodToJsonSchema } from 'zod-to-json-schema'
 import type {
   WorkerToolRegistry,
   WorkerToolContext,
@@ -86,18 +87,25 @@ function toWorkerMessage(msg: Message | ExtendedMessage): WorkerMessage {
 /**
  * Convert tool definition to core format.
  * Handles both Zod schemas and raw JSON schemas.
+ * Zod schemas are converted to JSON Schema since they contain functions
+ * that can't be cloned for postMessage to the host thread.
  */
 function toWorkerToolDefinition(tool: SamplingToolDefinition): {
   name: string
   description?: string
   inputSchema: Record<string, unknown>
 } {
-  // The inputSchema should already be a JSON Schema object (not a Zod type)
-  // since it comes from the sampling tool definition
+  // Check if inputSchema is a Zod type (has safeParse) and convert to JSON Schema
+  const schema = tool.inputSchema as unknown
+  const isZodSchema = schema && typeof (schema as { safeParse?: unknown }).safeParse === 'function'
+  const inputSchema = isZodSchema
+    ? zodToJsonSchema(schema as any, { $refStrategy: 'none', target: 'jsonSchema7' }) as Record<string, unknown>
+    : tool.inputSchema as Record<string, unknown>
+
   return {
     name: tool.name,
     ...(tool.description !== undefined && { description: tool.description }),
-    inputSchema: tool.inputSchema as Record<string, unknown>,
+    inputSchema,
   }
 }
 
@@ -193,9 +201,11 @@ function createMcpWorkerContext(
 
     // Handle schema (convert Zod to JSON schema marker)
     if ('schema' in config && config.schema) {
-      // The schema will be handled by the sampling provider
-      // For now, we pass a marker that indicates structured output is expected
-      coreOptions.schema = { $zodSchema: true }
+      const schema = config.schema as unknown
+      const isZodSchema = typeof (schema as { safeParse?: unknown }).safeParse === 'function'
+      coreOptions.schema = isZodSchema
+        ? zodToJsonSchema(schema as any, { $refStrategy: 'none', target: 'jsonSchema7' }) as Record<string, unknown>
+        : schema as Record<string, unknown>
     }
 
     // Handle tools
@@ -260,8 +270,14 @@ function createMcpWorkerContext(
 
   // The context object
   const ctx: WorkerToolContext = {
-    log(level: LogLevel, message: string): void {
+    log(level: LogLevel, message: string): Operation<void> {
       coreCtx.log(level, message)
+      // Return a no-op operation so callers can yield* ctx.log(...)
+      return {
+        *[Symbol.iterator]() {
+          // No-op - logging is fire-and-forget
+        },
+      }
     },
 
     progress(message: string, progressValue?: number): Operation<void> {
@@ -273,6 +289,11 @@ function createMcpWorkerContext(
           // No-op - progress is fire-and-forget in the new model
         },
       }
+    },
+
+    // Alias for progress() - MCP tools call ctx.notify() instead of ctx.progress()
+    notify(message: string, progressValue?: number): Operation<void> {
+      return ctx.progress(message, progressValue)
     },
 
     // Sample - delegates to sampleImpl (overloads are defined in the interface)
@@ -375,9 +396,23 @@ function createMcpWorkerContext(
 
     *elicit<T>(
       key: string,
-      options: { message: string; schema: Record<string, unknown> }
+      options: {
+        message: string
+        schema?: Record<string, unknown>
+        context?: Record<string, unknown>
+        [key: string]: unknown
+      }
     ): Operation<ElicitResult<unknown, T>> {
-      const response: WorkerElicitResponse = yield* coreCtx.elicit(key, options)
+      const { message, schema, context, ...spreadContext } = options
+      const resolvedContext = context !== undefined
+        ? context
+        : (Object.keys(spreadContext).length > 0 ? spreadContext : undefined)
+
+      const response: WorkerElicitResponse = yield* coreCtx.elicit(key, {
+        message,
+        schema: schema ?? { type: 'object' },
+        ...(resolvedContext !== undefined && { context: resolvedContext }),
+      })
 
       // Map core response to MCP elicit result
       if (response.status === 'accepted') {
@@ -407,12 +442,12 @@ function createMcpWorkerContext(
           action: 'accept',
           content,
           exchange: {
-            context: {} as unknown,
+            context: (resolvedContext ?? {}) as unknown,
             request,
             response: responseMsg,
             messages: [request, responseMsg] as [typeof request, typeof responseMsg],
             withArguments(fn: (ctx: unknown) => Record<string, unknown>) {
-              const args = fn({})
+              const args = fn(resolvedContext ?? {})
               const requestWithArgs = {
                 role: 'assistant' as const,
                 content: [{

--- a/packages/framework/src/lib/chat/mcp-tools/session/worker-session-api.ts
+++ b/packages/framework/src/lib/chat/mcp-tools/session/worker-session-api.ts
@@ -1,0 +1,156 @@
+/**
+ * Worker Session API
+ *
+ * Provides middleware-decoratable operations for worker session request/response
+ * handling using Effection's experimental createApi.
+ */
+
+import { createApi } from 'effection/experimental'
+import { createChannel, type Operation } from 'effection'
+import type {
+  WorkerElicitRequest,
+  WorkerElicitResponse,
+  WorkerSampleRequest,
+  WorkerSampleResponse,
+} from '@sweatpants/core/transport/worker'
+import type { RawElicitResult, Message } from '../mcp-tool-types.ts'
+import { MODEL_CONTEXT_SCHEMA_KEY } from '../model-context.ts'
+import type { RawSampleResult } from './types.ts'
+import { WorkerSessionStateContext } from './worker-session-context.ts'
+
+export const WorkerSessionApi = createApi('worker-session', {
+  // ==========================================
+  // Request side (worker → host)
+  // ==========================================
+
+  *handleElicitRequest(request: WorkerElicitRequest): Operation<WorkerElicitResponse> {
+    const state = yield* WorkerSessionStateContext.expect()
+    const elicitId = request.id
+
+    const schemaWithContext = request.context
+      ? { ...request.schema, [MODEL_CONTEXT_SCHEMA_KEY]: request.context }
+      : request.schema
+
+    yield* state.emitEvent({
+      type: 'elicit_request',
+      elicitId,
+      key: request.key,
+      message: request.message,
+      schema: schemaWithContext,
+      ...(request.context !== undefined && { context: request.context }),
+    })
+
+    const channel = createChannel<RawElicitResult<unknown>, void>()
+    state.pendingElicitChannels.set(elicitId, channel)
+
+    const sub = yield* channel
+    const result = yield* sub.next()
+
+    state.pendingElicitChannels.delete(elicitId)
+
+    if (result.done) {
+      return { id: elicitId, type: 'elicit', status: 'cancelled' }
+    }
+
+    const rawResult = result.value
+    state.setStatus('running')
+
+    const responseStatus = rawResult.action === 'accept' ? 'accepted'
+      : rawResult.action === 'decline' ? 'declined'
+      : 'cancelled'
+
+    return {
+      id: elicitId,
+      type: 'elicit',
+      status: responseStatus,
+      ...(rawResult.action === 'accept' && { content: rawResult.content }),
+    }
+  },
+
+  *handleSampleRequest(request: WorkerSampleRequest): Operation<WorkerSampleResponse> {
+    const state = yield* WorkerSessionStateContext.expect()
+    const sampleId = request.id
+
+    const messages: Message[] = request.messages.map((message) => {
+      if (typeof message.content === 'string') {
+        return { role: message.role, content: message.content }
+      }
+      return { role: message.role, content: JSON.stringify(message.content) }
+    })
+
+    yield* state.emitEvent({
+      type: 'sample_request',
+      sampleId,
+      messages,
+      ...(request.systemPrompt !== undefined && { systemPrompt: request.systemPrompt }),
+      ...(request.maxTokens !== undefined && { maxTokens: request.maxTokens }),
+      ...(request.modelPreferences !== undefined && { modelPreferences: request.modelPreferences }),
+      ...(request.tools !== undefined && { tools: request.tools }),
+      ...(request.toolChoice !== undefined && { toolChoice: request.toolChoice }),
+      ...(request.schema !== undefined && { schema: request.schema }),
+    })
+
+    const channel = createChannel<RawSampleResult, void>()
+    state.pendingSampleChannels.set(sampleId, channel)
+
+    const sub = yield* channel
+    const result = yield* sub.next()
+
+    state.pendingSampleChannels.delete(sampleId)
+
+    if (result.done) {
+      return {
+        id: sampleId,
+        type: 'sample',
+        status: 'accepted',
+        text: '',
+      }
+    }
+
+    const rawResult = result.value
+    state.setStatus('running')
+
+    return {
+      id: sampleId,
+      type: 'sample',
+      status: 'accepted',
+      text: rawResult.text,
+      ...(rawResult.model !== undefined && { model: rawResult.model }),
+      ...(rawResult.stopReason !== undefined && { stopReason: rawResult.stopReason }),
+      ...('parsed' in rawResult && rawResult.parsed !== undefined && { parsed: rawResult.parsed }),
+      ...('parseError' in rawResult && rawResult.parseError !== undefined && { parseError: rawResult.parseError }),
+      ...('toolCalls' in rawResult && rawResult.toolCalls !== undefined && { toolCalls: rawResult.toolCalls }),
+    }
+  },
+
+  // ==========================================
+  // Response side (host → worker)
+  // ==========================================
+
+  *respondToElicit(elicitId: string, response: RawElicitResult<unknown>): Operation<void> {
+    const state = yield* WorkerSessionStateContext.expect()
+    const channel = state.pendingElicitChannels.get(elicitId)
+    if (channel) {
+      yield* channel.send(response)
+      yield* channel.close()
+      state.pendingElicitChannels.delete(elicitId)
+    }
+  },
+
+  *respondToSample(sampleId: string, response: RawSampleResult): Operation<void> {
+    const state = yield* WorkerSessionStateContext.expect()
+    const channel = state.pendingSampleChannels.get(sampleId)
+    if (channel) {
+      yield* channel.send(response)
+      yield* channel.close()
+      state.pendingSampleChannels.delete(sampleId)
+    }
+  },
+})
+
+export const {
+  handleElicitRequest,
+  handleSampleRequest,
+  respondToElicit,
+  respondToSample,
+} = WorkerSessionApi.operations

--- a/packages/framework/src/lib/chat/mcp-tools/session/worker-session-context.ts
+++ b/packages/framework/src/lib/chat/mcp-tools/session/worker-session-context.ts
@@ -1,0 +1,30 @@
+/**
+ * Worker Session Context
+ *
+ * Provides context access to worker session state for API operations.
+ */
+
+import { createContext, type Channel, type Operation } from 'effection'
+import type { RawElicitResult } from '../mcp-tool-types.ts'
+import type { ToolSessionEvent, ToolSessionStatus, RawSampleResult } from './types.ts'
+
+export interface WorkerSessionState {
+  /** Pending elicit channels, keyed by elicitId */
+  pendingElicitChannels: Map<string, Channel<RawElicitResult<unknown>, void>>
+
+  /** Pending sample channels, keyed by sampleId */
+  pendingSampleChannels: Map<string, Channel<RawSampleResult, void>>
+
+  /** Emit a session event (adds LSN/timestamp internally) */
+  emitEvent(event: { type: ToolSessionEvent['type'] } & Record<string, unknown>): Operation<void>
+
+  /** Generate the next LSN */
+  nextLsn(): number
+
+  /** Update session status */
+  setStatus(status: ToolSessionStatus): void
+}
+
+export const WorkerSessionStateContext = createContext<WorkerSessionState>(
+  'worker-session.state'
+)

--- a/packages/framework/src/lib/chat/mcp-tools/session/worker-tool-session.ts
+++ b/packages/framework/src/lib/chat/mcp-tools/session/worker-tool-session.ts
@@ -33,6 +33,7 @@ import {
   type Operation,
   type Stream,
   type Subscription,
+  type Channel,
   resource,
   createChannel,
   spawn,
@@ -42,8 +43,6 @@ import {
   type WorkerRequest,
   type WorkerResponse,
   type WorkerResult,
-  type WorkerProgressMessage,
-  type ForEachContext,
 } from '@sweatpants/core/transport/worker'
 import type {
   ToolSession,
@@ -53,6 +52,8 @@ import type {
 } from './types.ts'
 import type { RawElicitResult, Message } from '../mcp-tool-types.ts'
 import type { McpWorkerInitData } from './worker-types.ts'
+import { WorkerSessionStateContext, type WorkerSessionState } from './worker-session-context.ts'
+import { WorkerSessionApi } from './worker-session-api.ts'
 
 // =============================================================================
 // WORKER TOOL SESSION
@@ -74,59 +75,26 @@ export interface WorkerToolSessionOptions {
   systemPrompt?: string
   /** Optional parent messages */
   parentMessages?: Message[]
+  /** Extra execArgv for the worker thread (e.g., ['--import', 'tsx'] for TypeScript support) */
+  execArgv?: string[]
 }
-
-/**
- * Handler for sample requests from the worker.
- * Called when the worker tool calls ctx.sample().
- */
-export type SampleRequestHandler = (
-  request: {
-    sampleId: string
-    messages: Message[]
-    systemPrompt?: string
-    maxTokens?: number
-    tools?: Array<{ name: string; description?: string; inputSchema: Record<string, unknown> }>
-    toolChoice?: 'auto' | 'none' | 'required' | { type: 'tool'; name: string }
-    schema?: Record<string, unknown>
-  },
-  ctx: ForEachContext<WorkerProgressMessage>
-) => Operation<RawSampleResult>
-
-/**
- * Handler for elicit requests from the worker.
- * Called when the worker tool calls ctx.elicit().
- */
-export type ElicitRequestHandler = (
-  request: {
-    elicitId: string
-    key: string
-    message: string
-    schema: Record<string, unknown>
-  },
-  ctx: ForEachContext<WorkerProgressMessage>
-) => Operation<RawElicitResult<unknown>>
 
 /**
  * Create a ToolSession backed by a web worker.
  *
  * This resource:
  * 1. Spawns a worker with the tool to execute
- * 2. Handles requests from the worker (sample/elicit) via callbacks
+ * 2. Handles requests from the worker via WorkerSessionApi operations
  * 3. Exposes the ToolSession interface for the host to interact
  *
  * @param options - Session configuration
- * @param onSampleRequest - Handler for sample requests
- * @param onElicitRequest - Handler for elicit requests
  * @returns A ToolSession resource
  */
 export function createWorkerToolSession(
-  options: WorkerToolSessionOptions,
-  onSampleRequest: SampleRequestHandler,
-  onElicitRequest: ElicitRequestHandler
+  options: WorkerToolSessionOptions
 ): Operation<ToolSession> {
   return resource<ToolSession>(function* (provide) {
-    const { sessionId, toolName, params, workerUrl, systemPrompt, parentMessages } = options
+    const { sessionId, toolName, params, workerUrl, systemPrompt, parentMessages, execArgv } = options
 
     // State
     let status: ToolSessionStatus = 'initializing'
@@ -136,13 +104,13 @@ export function createWorkerToolSession(
     // Channel for streaming events to subscribers
     const eventChannel = createChannel<ToolSessionEvent, void>()
 
-    // Pending requests (for respondToSample/respondToElicit)
-    const pendingSamples = new Map<string, {
-      resolve: (response: RawSampleResult) => void
-    }>()
-    const pendingElicits = new Map<string, {
-      resolve: (response: RawElicitResult<unknown>) => void
-    }>()
+    const pendingSamples = new Map<string, Channel<RawSampleResult, void>>()
+    const pendingElicits = new Map<string, Channel<RawElicitResult<unknown>, void>>()
+
+    function nextLsn(): number {
+      lsn += 1
+      return lsn
+    }
 
     // Helper to emit events
     // Using a more permissive input type to avoid TypeScript's excess property checking issues
@@ -152,7 +120,7 @@ export function createWorkerToolSession(
     ): Operation<void> {
       const fullEvent: ToolSessionEvent = {
         ...event,
-        lsn: ++lsn,
+        lsn: nextLsn(),
         timestamp: Date.now(),
       } as ToolSessionEvent
 
@@ -187,6 +155,18 @@ export function createWorkerToolSession(
       yield* eventChannel.send(fullEvent)
     }
 
+    const sessionState: WorkerSessionState = {
+      pendingElicitChannels: pendingElicits,
+      pendingSampleChannels: pendingSamples,
+      emitEvent,
+      nextLsn,
+      setStatus: (nextStatus: ToolSessionStatus) => {
+        status = nextStatus
+      },
+    }
+
+    yield* WorkerSessionStateContext.set(sessionState)
+
     // Build init data for the worker
     const initData: McpWorkerInitData = {
       toolName,
@@ -197,109 +177,25 @@ export function createWorkerToolSession(
     }
 
     // Create the worker using core's createWorkerPrincipal
+    // Note: We use WorkerSessionStateContext.with() to ensure the context is available
+    // in the spawned request handler scope inside createWorkerPrincipal
     const { result: workerResult } = yield* createWorkerPrincipal<unknown>({
       workerUrl,
       initData: initData as unknown as Parameters<typeof createWorkerPrincipal>[0]['initData'],
-      requestHandler: function* (request: WorkerRequest, ctx: ForEachContext<WorkerProgressMessage>): Operation<WorkerResponse> {
-        const requestId = request.id
-
-        if (request.type === 'sample') {
-          const sampleId = requestId
-
-          // Emit sample request event
-          yield* emitEvent({
-            type: 'sample_request',
-            sampleId,
-            messages: request.messages.map(m => ({
-              role: m.role,
-              content: typeof m.content === 'string' ? m.content : JSON.stringify(m.content),
-            })),
-            ...(request.systemPrompt !== undefined && { systemPrompt: request.systemPrompt }),
-            ...(request.maxTokens !== undefined && { maxTokens: request.maxTokens }),
-            ...(request.tools !== undefined && { tools: request.tools }),
-            ...(request.toolChoice !== undefined && { toolChoice: request.toolChoice }),
-            ...(request.schema !== undefined && { schema: request.schema }),
-          })
-
-          // Call the sample handler (this may call respondToSample later)
-          const rawResult = yield* onSampleRequest(
-            {
-              sampleId,
-              messages: request.messages.map(m => ({
-                role: m.role,
-                content: typeof m.content === 'string' ? m.content : JSON.stringify(m.content),
-              })),
-              ...(request.systemPrompt !== undefined && { systemPrompt: request.systemPrompt }),
-              ...(request.maxTokens !== undefined && { maxTokens: request.maxTokens }),
-              ...(request.tools !== undefined && { tools: request.tools }),
-              ...(request.toolChoice !== undefined && { toolChoice: request.toolChoice }),
-              ...(request.schema !== undefined && { schema: request.schema }),
-            },
-            ctx
-          )
-
-          // Mark as running again
-          status = 'running'
-
-          // Build response
-          const response: WorkerResponse = {
-            id: requestId,
-            type: 'sample',
-            status: 'accepted',
-            text: rawResult.text,
-            ...(rawResult.model !== undefined && { model: rawResult.model }),
-            ...(rawResult.stopReason !== undefined && { stopReason: rawResult.stopReason }),
-            ...('parsed' in rawResult && rawResult.parsed !== undefined && { parsed: rawResult.parsed }),
-            ...('parseError' in rawResult && rawResult.parseError !== undefined && { parseError: rawResult.parseError }),
-            ...('toolCalls' in rawResult && rawResult.toolCalls !== undefined && { toolCalls: rawResult.toolCalls }),
+      ...(execArgv && execArgv.length > 0 ? { execArgv } : {}),
+      requestHandler: function* (request: WorkerRequest): Operation<WorkerResponse> {
+        // Re-establish context for this handler scope
+        return yield* WorkerSessionStateContext.with(sessionState, function* () {
+          if (request.type === 'sample') {
+            return yield* WorkerSessionApi.operations.handleSampleRequest(request)
           }
 
-          return response
-        }
-
-        if (request.type === 'elicit') {
-          const elicitId = requestId
-
-          // Emit elicit request event
-          yield* emitEvent({
-            type: 'elicit_request',
-            elicitId,
-            key: request.key,
-            message: request.message,
-            schema: request.schema,
-          })
-
-          // Call the elicit handler
-          const rawResult = yield* onElicitRequest(
-            {
-              elicitId,
-              key: request.key,
-              message: request.message,
-              schema: request.schema,
-            },
-            ctx
-          )
-
-          // Mark as running again
-          status = 'running'
-
-          // Map action to status
-          const responseStatus = rawResult.action === 'accept' ? 'accepted'
-            : rawResult.action === 'decline' ? 'declined'
-            : 'cancelled'
-
-          // Build response
-          const response: WorkerResponse = {
-            id: requestId,
-            type: 'elicit',
-            status: responseStatus,
-            ...(rawResult.action === 'accept' && { content: rawResult.content }),
+          if (request.type === 'elicit') {
+            return yield* WorkerSessionApi.operations.handleElicitRequest(request)
           }
 
-          return response
-        }
-
-        throw new Error(`Unknown request type: ${(request as WorkerRequest).type}`)
+          throw new Error(`Unknown request type: ${(request as WorkerRequest).type}`)
+        })
       },
     })
 
@@ -311,33 +207,33 @@ export function createWorkerToolSession(
       try {
         const result: WorkerResult<unknown> = yield* workerResult
 
-          if (result.type === 'success') {
-            yield* emitEvent({
-              type: 'result',
-              result: result.value,
-            })
-          } else if (result.type === 'error') {
-            yield* emitEvent({
-              type: 'error',
-              name: result.error.name,
-              message: result.error.message,
-              ...(result.error.stack !== undefined && { stack: result.error.stack }),
-            })
-          } else if (result.type === 'cancelled') {
-            yield* emitEvent({
-              type: 'cancelled',
-              ...(result.reason !== undefined && { reason: result.reason }),
-            })
-          }
-        } catch (error) {
-          const err = error as Error
+        if (result.type === 'success') {
+          yield* emitEvent({
+            type: 'result',
+            result: result.value,
+          })
+        } else if (result.type === 'error') {
           yield* emitEvent({
             type: 'error',
-            name: err.name,
-            message: err.message,
-            ...(err.stack !== undefined && { stack: err.stack }),
+            name: result.error.name,
+            message: result.error.message,
+            ...(result.error.stack !== undefined && { stack: result.error.stack }),
           })
-        } finally {
+        } else if (result.type === 'cancelled') {
+          yield* emitEvent({
+            type: 'cancelled',
+            ...(result.reason !== undefined && { reason: result.reason }),
+          })
+        }
+      } catch (error) {
+        const err = error as Error
+        yield* emitEvent({
+          type: 'error',
+          name: err.name,
+          message: err.message,
+          ...(err.stack !== undefined && { stack: err.stack }),
+        })
+      } finally {
         yield* eventChannel.close()
       }
     })
@@ -354,7 +250,11 @@ export function createWorkerToolSession(
       events(afterLSN?: number): Stream<ToolSessionEvent, void> {
         // Return a stream that replays buffered events then subscribes to new ones
         return resource<Subscription<ToolSessionEvent, void>>(function* (provideStream) {
-          // Subscribe to the channel for new events
+          // Snapshot the buffer length at subscription time
+          // Events added after this point will come from the channel
+          const bufferSnapshotLength = eventBuffer.length
+
+          // Subscribe to the channel for new events AFTER snapshotting
           const channelSub = yield* eventChannel
 
           // Combine buffered events with live stream
@@ -362,14 +262,15 @@ export function createWorkerToolSession(
 
           yield* provideStream({
             *next() {
-              // First drain buffered events
-              if (bufferedIndex < eventBuffer.length) {
+              // First drain buffered events up to the snapshot point
+              if (bufferedIndex < bufferSnapshotLength) {
                 const event = eventBuffer[bufferedIndex]!
                 bufferedIndex++
                 return { done: false, value: event }
               }
 
-              // Then read from live channel
+              // Then read from live channel (no deduplication needed since we
+              // snapshotted the buffer before subscribing to the channel)
               return yield* channelSub.next()
             },
           })
@@ -377,23 +278,15 @@ export function createWorkerToolSession(
       },
 
       *respondToElicit(elicitId: string, response: RawElicitResult<unknown>): Operation<void> {
-        const pending = pendingElicits.get(elicitId)
-        if (pending) {
-          pending.resolve(response)
-          pendingElicits.delete(elicitId)
-        }
-        // Note: With the new architecture, responses flow through the request handler,
-        // not through explicit respondTo calls. This is kept for API compatibility.
+        yield* WorkerSessionStateContext.with(sessionState, function* () {
+          yield* WorkerSessionApi.operations.respondToElicit(elicitId, response)
+        })
       },
 
       *respondToSample(sampleId: string, response: RawSampleResult): Operation<void> {
-        const pending = pendingSamples.get(sampleId)
-        if (pending) {
-          pending.resolve(response)
-          pendingSamples.delete(sampleId)
-        }
-        // Note: With the new architecture, responses flow through the request handler,
-        // not through explicit respondTo calls. This is kept for API compatibility.
+        yield* WorkerSessionStateContext.with(sessionState, function* () {
+          yield* WorkerSessionApi.operations.respondToSample(sampleId, response)
+        })
       },
 
       *cancel(reason?: string): Operation<void> {
@@ -415,6 +308,14 @@ export function createWorkerToolSession(
     try {
       yield* provide(session)
     } finally {
+      for (const channel of pendingElicits.values()) {
+        yield* channel.close()
+      }
+      for (const channel of pendingSamples.values()) {
+        yield* channel.close()
+      }
+      pendingElicits.clear()
+      pendingSamples.clear()
       yield* eventChannel.close()
     }
   })


### PR DESCRIPTION
Not intended for merge, just for a tighter diff on the changes needed for worker transport

the important files are 

packages/core/* <- very few changes needed in the core, just had to move some exports and the compiler was complaining about the infer as ZodInfer


the following files are the majority of the integration:
 
packages/framework/src/lib/chat/mcp-tools/session/worker-exports.ts
packages/framework/src/lib/chat/mcp-tools/session/worker-runner.ts
packages/framework/src/lib/chat/mcp-tools/session/worker-session-api.ts <-- this one in particular
packages/framework/src/lib/chat/mcp-tools/session/worker-session-context.ts
packages/framework/src/lib/chat/mcp-tools/session/worker-tool-session.ts
